### PR TITLE
Fix NullPointerException in loading configuration (#9)

### DIFF
--- a/tools/oculus/src/main/java/com/iris/oculus/modules/session/SessionController.java
+++ b/tools/oculus/src/main/java/com/iris/oculus/modules/session/SessionController.java
@@ -627,7 +627,7 @@ public class SessionController {
    @Nullable
    private OculusSession getLastSession() {
       List<OculusSession> info = listRecentSessions();
-      if(info.isEmpty()) {
+      if(info == null || info.isEmpty()) {
          return null;
       }
       return info.get(0);


### PR DESCRIPTION
Fixes the null pointer exception on startup of oculus documented in #9 