### PR TITLE
Allow device-ota-firmware to be set via environment variables (fixes #33)

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/firmware/ota/DeviceOTAFirmwareURLBuilder.java
+++ b/platform/arcus-lib/src/main/java/com/iris/firmware/ota/DeviceOTAFirmwareURLBuilder.java
@@ -27,11 +27,11 @@ import com.iris.firmware.FirmwareURLBuilder;
 public class DeviceOTAFirmwareURLBuilder implements FirmwareURLBuilder<String> {
 
    @Inject(optional = true)
-   @Named("device-ota-firmware.download.scheme")
+   @Named("device.ota.firmware.download.scheme")
    private String firmwareDownloadScheme = "https";
 
    @Inject
-   @Named("device-ota-firmware.download.host")
+   @Named("device.ota.firmware.download.host")
    private String firmwareDownloadHost;
 
    @Override

--- a/platform/arcus-test/src/main/java/com/iris/test/IrisMockTestCase.java
+++ b/platform/arcus-test/src/main/java/com/iris/test/IrisMockTestCase.java
@@ -33,7 +33,7 @@ public class IrisMockTestCase extends IrisTestCase {
 
    static {
       System.setProperty("redirect.base.url", "http://fakeurl");
-      System.setProperty("device-ota-firmware.download.host", "http://fakeurl");
+      System.setProperty("device.ota.firmware.download.host", "http://fakeurl");
    }
 
    private MockModule mocks;


### PR DESCRIPTION
This allows device-ota-firmware to be configured via environment variables, to allow for easy configuration in production.