### PR TITLE
Provide AlarmIncidentServiceImpl.NAME_EXECUTOR_POOL (addresses #15)

### DIFF
--- a/platform/arcus-containers/subsystem-service/src/main/java/com/iris/platform/subsystem/SubsystemModule.java
+++ b/platform/arcus-containers/subsystem-service/src/main/java/com/iris/platform/subsystem/SubsystemModule.java
@@ -50,6 +50,7 @@ import com.iris.platform.subsystem.cellbackup.CellBackupNotifications;
 import com.iris.platform.subsystem.cellbackup.CellBackupSubsystem;
 import com.iris.platform.subsystem.impl.CachingSubsystemRegistry;
 import com.iris.platform.subsystem.impl.PlatformSubsystemFactory;
+import com.iris.platform.subsystem.incident.AlarmIncidentServiceImpl;
 import com.iris.platform.subsystem.pairing.PairingSubsystem;
 import com.iris.platform.subsystem.placemonitor.PlaceMonitorHandler;
 import com.iris.platform.subsystem.placemonitor.PlaceMonitorNotifications;
@@ -162,5 +163,10 @@ public class SubsystemModule extends AbstractIrisModule {
    	return executorRef.get();
    }
 
+    @Provides @Named(AlarmIncidentServiceImpl.NAME_EXECUTOR_POOL)
+    public ExecutorService incidentServiceExecutor(SubsystemConfig config) {
+        this.config = config;
+        return executorRef.get();
+    }
 }
 


### PR DESCRIPTION
This addresses #15.

Testing: I was able to start the subsystem-service with this change (note, it wasn't previously able to start due to the error in #15), and then I did some basic testing by pressing the "panic" button on my keypad, and noted nothing out of the ordinary in my subsystem-service logs.

```
D0430 02:10:12.721 ice-85               subsystem.subalarm] Incident is complete and hub is disarmed or missing, completing incident
D0430 02:10:12.736 ice-85     c.i.m.model.SimpleModelStore] Received value change for un-tracked model [SERV:incident:0dcec980-6aed-11e9-a8c2-27877dd27d13]
D0430 02:10:12.736 ice-85               subsystem.subalarm] Completed incident [SERV:incident:0dcec980-6aed-11e9-a8c2-27877dd27d13]
```