### PR TITLE
Add support for using tls key/cert without using java KeyStore

### DIFF
--- a/platform/bridge-common/src/main/java/com/iris/bridge/server/config/BridgeServerConfig.java
+++ b/platform/bridge-common/src/main/java/com/iris/bridge/server/config/BridgeServerConfig.java
@@ -66,6 +66,12 @@ public class BridgeServerConfig {
    @Inject(optional = true) @Named("tls.server.keystore.password")
    private String tlsServerKeystorePassword = "password";
 
+   @Inject(optional = true) @Named("tls.server.cert.filepath")
+   private String tlsServerCertificateFilepath = "";
+
+   @Inject(optional = true) @Named("tls.server.privatekey.filepath")
+   private String tlsServerPrivateKeyFilepath = "";
+
    @Inject(optional = true) @Named("tls.server.key.password")
    private String tlsServerKeyPassword = "keypass";
 
@@ -241,6 +247,10 @@ public class BridgeServerConfig {
    public void setTlsServerKeyPassword(String tlsServerKeyPassword) {
       this.tlsServerKeyPassword = tlsServerKeyPassword;
    }
+
+   public String getTlsServerCertificateFilepath() { return tlsServerCertificateFilepath;}
+
+   public String getTlsServerPrivateKeyFilepath() { return tlsServerPrivateKeyFilepath;}
 
    public boolean isTlsNeedClientAuth() {
       return tlsNeedClientAuth;


### PR DESCRIPTION
This change allows the trust store for a bridge (especially for the hub-bridge), to be configured with a PKCS#8 Private Key and PEM encoded certificates, simplifying the process to setup the hub-bridge. This also allows kubernetes cert-manager to automatically issue (and renew) certificates for Arcus once PKCS#8 support lands there (currently it only supports PKCS#1 which netty does not support)