### PR TITLE
Allow kafka server name to be configured

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/AbstractKafkaConfig.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/AbstractKafkaConfig.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.Nullable;
@@ -116,7 +117,7 @@ public abstract class AbstractKafkaConfig {
    private String secondaryBootstrapServers = null;
 
    // shared global config
-   @Named("bootstrap.servers") // not auto-populated because this is expanded on client creation
+   @Inject(optional = True) @Named("bootstrap.servers") // not auto-populated because this is expanded on client creation
    private String bootstrapServers;
    @Consumer @Producer @Named("client.id")
    private String clientId;

--- a/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/AbstractKafkaConfig.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/AbstractKafkaConfig.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.Nullable;
@@ -41,6 +40,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.netflix.governator.configuration.ConfigurationKey;
 import com.netflix.governator.configuration.ConfigurationProvider;

--- a/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/AbstractKafkaConfig.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/AbstractKafkaConfig.java
@@ -117,7 +117,7 @@ public abstract class AbstractKafkaConfig {
    private String secondaryBootstrapServers = null;
 
    // shared global config
-   @Inject(optional = True) @Named("bootstrap.servers") // not auto-populated because this is expanded on client creation
+   @Inject(optional = true) @Named("bootstrap.servers") // not auto-populated because this is expanded on client creation
    private String bootstrapServers;
    @Consumer @Producer @Named("client.id")
    private String clientId;

--- a/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/KafkaOpsConfig.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/messaging/kafka/KafkaOpsConfig.java
@@ -24,7 +24,10 @@ import com.netflix.governator.configuration.ConfigurationProvider;
 public class KafkaOpsConfig extends AbstractKafkaConfig {
    @Inject(optional = true) @Named("ops.kafka.topic.metrics") 
 	private String topicMetrics = "metrics";
-   
+
+   @Inject(optional = true) @Named("ops.bootstrap.servers")
+   private String bootstrapServers;
+
    @Inject
    public KafkaOpsConfig(ConfigurationProvider configProvider) {
       super(configProvider, "ops.");


### PR DESCRIPTION
Allow the hostname to be changed, aiding with use of kubernetes service discovery where the DNS name can't be changed to kafka.eyeris