### PR TITLE
Use correct class for logger

### DIFF
--- a/agent/arcus-reflex-controller/src/main/java/com/iris/agent/reflex/drivers/AlertmeKeyPad.java
+++ b/agent/arcus-reflex-controller/src/main/java/com/iris/agent/reflex/drivers/AlertmeKeyPad.java
@@ -57,7 +57,7 @@ import com.iris.util.IrisUUID;
 import rx.Observable;
 
 public class AlertmeKeyPad extends AbstractZigbeeHubDriver {
-   private static final Logger log = LoggerFactory.getLogger(CentraLiteKeyPad.class);
+   private static final Logger log = LoggerFactory.getLogger(AlertmeKeyPad.class);
 
    private static final long PIN_VALIDITY_TIME = TimeUnit.SECONDS.toNanos(10);
    private static final long UPDATE_KEYPAD_STATE_DWELL_TIME = TimeUnit.SECONDS.toNanos(5);


### PR DESCRIPTION
The AlertMe keypad driver was using the Centralite class for logging, thus creating confusing log messages on the hub from the AlertMe keypad as a Centralite Device