### PR TITLE
Add support for cassandra 3.x

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext.libraries << [
 
 
 // Cassandra
-		cassandraDriver: dependencies.create("com.datastax.cassandra:cassandra-driver-core:2.1.10.3:shaded") {
+		cassandraDriver: dependencies.create("com.datastax.cassandra:cassandra-driver-core:3.0.8:shaded") {
 			exclude group: "com.codahale.metrics" // interferes with platform dropwizard metrics
 			exclude group: "io.netty"
 		},

--- a/platform/arcus-containers/voice-service/src/main/java/com/iris/voice/proactive/ProactiveCredsDAO.java
+++ b/platform/arcus-containers/voice-service/src/main/java/com/iris/voice/proactive/ProactiveCredsDAO.java
@@ -75,7 +75,7 @@ public class ProactiveCredsDAO {
          return rs.all().stream()
             .collect(Collectors.toMap(
                row -> row.getString(Columns.assistant.name()),
-               row -> new ProactiveCreds(row.getString(Columns.access.name()), row.getDate(Columns.accessExpiry.name()), row.getString(Columns.refresh.name()))
+               row -> new ProactiveCreds(row.getString(Columns.access.name()), row.getTimestamp(Columns.accessExpiry.name()), row.getString(Columns.refresh.name()))
                )
             );
       }
@@ -88,7 +88,7 @@ public class ProactiveCredsDAO {
          stmt.setString(Columns.assistant.name(), assistant);
          stmt.setString(Columns.access.name(), credentials.getAccess());
          if(credentials.getAccessExpiry() != null) {
-            stmt.setDate(Columns.accessExpiry.name(), credentials.getAccessExpiry());
+            stmt.setTimestamp(Columns.accessExpiry.name(), credentials.getAccessExpiry());
          } else {
             stmt.setToNull(Columns.accessExpiry.name());
          }

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/AccountDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/AccountDAOImpl.java
@@ -182,7 +182,7 @@ public class AccountDAOImpl extends BaseCassandraCRUDDao<UUID, Account> implemen
       }
       entity.setSubscriptionIDs(subIDs);
       entity.setOwner(row.getUUID(AccountEntityColumns.OWNER));
-      entity.setTrialEnd(row.getDate(AccountEntityColumns.TRIAL_END));
+      entity.setTrialEnd(row.getTimestamp(AccountEntityColumns.TRIAL_END));
    }
 
    @Override

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/BaseCassandraCRUDDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/BaseCassandraCRUDDao.java
@@ -416,8 +416,8 @@ public abstract class BaseCassandraCRUDDao<I, T extends BaseEntity<I, T>> implem
 
    protected final void populateBaseEntity(Row row, T entity) {
       entity.setId(getIdFromRow(row));
-      Date created = row.getDate(BaseEntityColumns.CREATED);
-      Date modified = row.getDate(BaseEntityColumns.MODIFIED);
+      Date created = row.getTimestamp(BaseEntityColumns.CREATED);
+      Date modified = row.getTimestamp(BaseEntityColumns.MODIFIED);
       Set<String> tags = row.getSet(BaseEntityColumns.TAGS, String.class);
       if(created == null) {
       	logger.debug("Repairing entity [{}] from [{}] with null created date", entity.getId(), getClass());

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/DeviceDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/DeviceDAOImpl.java
@@ -415,7 +415,7 @@ public class DeviceDAOImpl extends BaseCassandraCRUDDao<UUID, Device> implements
       setIf(DeviceCapability.ATTR_PRODUCTID, row.getString(DeviceEntityColumns.PRODUCTID), model);
 
       // device advanced attributes
-      setIf(DeviceAdvancedCapability.ATTR_ADDED, row.getDate(BaseEntityColumns.CREATED), model);
+      setIf(DeviceAdvancedCapability.ATTR_ADDED, row.getTimestamp(BaseEntityColumns.CREATED), model);
       setIf(DeviceAdvancedCapability.ATTR_DRIVERNAME, row.getString(DeviceEntityColumns.DRIVER_NAME), model);
 
       String version = row.getString(DeviceEntityColumns.DRIVER_VERSION2);
@@ -458,8 +458,8 @@ public class DeviceDAOImpl extends BaseCassandraCRUDDao<UUID, Device> implements
       }
 
       ModelEntity entity = new ModelEntity(attributes);
-      entity.setCreated(row.getDate(BaseEntityColumns.CREATED));
-      entity.setModified(row.getDate(BaseEntityColumns.MODIFIED));
+      entity.setCreated(row.getTimestamp(BaseEntityColumns.CREATED));
+      entity.setModified(row.getTimestamp(BaseEntityColumns.MODIFIED));
       return entity;
    }
 

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/HubDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/HubDAOImpl.java
@@ -476,7 +476,7 @@ public class HubDAOImpl extends BaseCassandraCRUDDao<String, Hub> implements Hub
       Calendar dayHour = DateUtils.truncate(snapped, Calendar.HOUR);
       hubSimIdMap.forEach((h,s) -> {
          BoundStatement stmt = new BoundStatement(insertCellBackupTime);
-         stmt.setDate(CellBackupCol.dayhour.name(), dayHour.getTime());
+         stmt.setTimestamp(CellBackupCol.dayhour.name(), dayHour.getTime());
          stmt.setInt(CellBackupCol.minute.name(), snapped.get(Calendar.MINUTE));
          stmt.setString(CellBackupCol.hubid.name(), h);
          stmt.setString(CellBackupCol.simid.name(), s);
@@ -641,8 +641,8 @@ public class HubDAOImpl extends BaseCassandraCRUDDao<String, Hub> implements Hub
       Map<String, Object> attributes = toAttributes(r);
 
       ModelEntity entity = new ModelEntity(attributes);
-      entity.setCreated(r.getDate(BaseEntityColumns.CREATED));
-      entity.setModified(r.getDate(BaseEntityColumns.MODIFIED));
+      entity.setCreated(r.getTimestamp(BaseEntityColumns.CREATED));
+      entity.setModified(r.getTimestamp(BaseEntityColumns.MODIFIED));
       return entity;
    }
 

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/HubRegistrationDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/HubRegistrationDAOImpl.java
@@ -131,17 +131,17 @@ public class HubRegistrationDAOImpl extends BaseCassandraCRUDDao<String, HubRegi
 
 	@Override
 	protected void populateEntity(Row row, HubRegistration entity) {
-		entity.setLastConnected(row.getDate(EntityColumns.LAST_CONNECTED));
+		entity.setLastConnected(row.getTimestamp(EntityColumns.LAST_CONNECTED));
 		if(!row.isNull(EntityColumns.STATE)) {
 			entity.setState(HubRegistration.RegistrationState.valueOf(row.getString(EntityColumns.STATE)));
 		}	      
-	    entity.setUpgradeRequestTime(row.getDate(EntityColumns.UPGRADE_REQUEST_TIME));
+	    entity.setUpgradeRequestTime(row.getTimestamp(EntityColumns.UPGRADE_REQUEST_TIME));
 	    entity.setFirmwareVersion(row.getString(EntityColumns.FIRMWARE_VERSION));
 	    entity.setTargetVersion(row.getString(EntityColumns.TARGET_VERSION));
 	    entity.setUpgradeErrorCode(row.getString(EntityColumns.UPGRADE_ERROR_CODE));
 	    entity.setUpgradeErrorMessage(row.getString(EntityColumns.UPGRADE_ERROR_MSG));
 	    entity.setDownloadProgress(row.getInt(EntityColumns.DOWNLOAD_PROGRESS));
-	    entity.setUpgradeErrorTime(row.getDate(EntityColumns.UPGRADE_ERROR_TIME));
+	    entity.setUpgradeErrorTime(row.getTimestamp(EntityColumns.UPGRADE_ERROR_TIME));
 	}
 
 

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/InvitationDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/InvitationDAOImpl.java
@@ -236,7 +236,7 @@ public class InvitationDAOImpl implements InvitationDAO {
             stmt.setUUID(Column.placeOwnerId.name(), UUID.fromString(invitation.getPlaceOwnerId()));
             stmt.setString(Column.placeOwnerFirstName.name(), invitation.getPlaceOwnerFirstName());
             stmt.setString(Column.placeOwnerLastName.name(), invitation.getPlaceOwnerLastName());
-            stmt.setDate(Column.created.name(), created);
+            stmt.setTimestamp(Column.created.name(), created);
             stmt.setDate(Column.accepted.name(), null);
             stmt.setDate(Column.rejected.name(), null);
             stmt.setString(Column.rejectReason.name(), invitation.getRejectReason());
@@ -282,7 +282,7 @@ public class InvitationDAOImpl implements InvitationDAO {
       try(Context timer = acceptTimer.time()) {
          BoundStatement stmt = new BoundStatement(acceptExistingPerson);
          stmt.setString(Column.code.name(), StringUtils.lowerCase(code));
-         stmt.setDate(Column.accepted.name(), new Date());
+         stmt.setTimestamp(Column.accepted.name(), new Date());
          session.execute(stmt);
       }
    }
@@ -296,7 +296,7 @@ public class InvitationDAOImpl implements InvitationDAO {
          BatchStatement batch = new BatchStatement();
          BoundStatement stmt = new BoundStatement(accept);
          stmt.setString(Column.code.name(), StringUtils.lowerCase(code));
-         stmt.setDate(Column.accepted.name(), new Date());
+         stmt.setTimestamp(Column.accepted.name(), new Date());
          stmt.setUUID(Column.inviteeId.name(), inviteeId);
          batch.add(stmt);
          batch.add(bindInsertPersonIdx(inviteeId, code));
@@ -311,7 +311,7 @@ public class InvitationDAOImpl implements InvitationDAO {
       try(Context timer = rejectTimer.time()) {
          BoundStatement stmt = new BoundStatement(reject);
          stmt.setString(Column.code.name(), StringUtils.lowerCase(code));
-         stmt.setDate(Column.rejected.name(), new Date());
+         stmt.setTimestamp(Column.rejected.name(), new Date());
          stmt.setString(Column.rejectReason.name(), reason);
          session.execute(stmt);
       }
@@ -335,7 +335,7 @@ public class InvitationDAOImpl implements InvitationDAO {
       try(Context timer = pendingForInviteeTimer.time()) {
          BoundStatement stmt = new BoundStatement(selectCodesForPerson);
          stmt.setUUID(Column.inviteeId.name(), inviteeId);
-         return listByIndex(stmt, (r) -> { return r.getDate(Column.accepted.name()) == null && r.getDate(Column.rejected.name()) == null; });
+         return listByIndex(stmt, (r) -> { return r.getTimestamp(Column.accepted.name()) == null && r.getTimestamp(Column.rejected.name()) == null; });
       }
    }
 
@@ -399,10 +399,10 @@ public class InvitationDAOImpl implements InvitationDAO {
          return null;
       }
       Invitation invitation = new Invitation();
-      invitation.setAccepted(r.getDate(Column.accepted.name()));
+      invitation.setAccepted(r.getTimestamp(Column.accepted.name()));
       invitation.setCity(r.getString(Column.city.name()));
       invitation.setCode(r.getString(Column.code.name()));
-      invitation.setCreated(r.getDate(Column.created.name()));
+      invitation.setCreated(r.getTimestamp(Column.created.name()));
       invitation.setInvitationText(r.getString(Column.invitationText.name()));
       invitation.setInviteeEmail(r.getString(Column.inviteeEmail.name()));
       invitation.setInviteeFirstName(r.getString(Column.inviteeFirstName.name()));
@@ -420,7 +420,7 @@ public class InvitationDAOImpl implements InvitationDAO {
       invitation.setPlaceOwnerFirstName(r.getString(Column.placeOwnerFirstName.name()));
       invitation.setPlaceOwnerId(r.getUUID(Column.placeOwnerId.name()).toString());
       invitation.setPlaceOwnerLastName(r.getString(Column.placeOwnerLastName.name()));
-      invitation.setRejected(r.getDate(Column.rejected.name()));
+      invitation.setRejected(r.getTimestamp(Column.rejected.name()));
       invitation.setRejectReason(r.getString(Column.rejectReason.name()));
       invitation.setRelationship(r.getString(Column.relationship.name()));
       invitation.setStateProv(r.getString(Column.stateProv.name()));

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/MobileDeviceDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/MobileDeviceDAOImpl.java
@@ -178,7 +178,7 @@ public class MobileDeviceDAOImpl implements MobileDeviceDAO {
       return new BoundStatement(upsertStatement)
       .setUUID("personId", device.getPersonId())
       .setInt("deviceIndex", device.getDeviceIndex())
-      .setDate("associated", device.getAssociated())
+      .setTimestamp("associated", device.getAssociated())
       .setString("osType", device.getOsType())
       .setString("osVersion", device.getOsVersion())
       .setString("formFactor", device.getFormFactor())
@@ -190,7 +190,7 @@ public class MobileDeviceDAOImpl implements MobileDeviceDAO {
       .setString("notificationToken", device.getNotificationToken())
       .setDouble("lastLatitude", device.getLastLatitude())
       .setDouble("lastLongitude", device.getLastLongitude())
-      .setDate("lastLocationTime", device.getLastLocationTime())
+      .setTimestamp("lastLocationTime", device.getLastLocationTime())
       .setString("name", device.getName())
       .setString("appVersion", device.getAppVersion());
    }
@@ -273,16 +273,16 @@ public class MobileDeviceDAOImpl implements MobileDeviceDAO {
 
    private MobileDevice createMobileDevice(Row row) {
       MobileDevice device = new MobileDevice();
-      device.setAssociated(row.getDate("associated"));
+      device.setAssociated(row.getTimestamp("associated"));
       device.setDeviceIdentifier(row.getString("deviceIdentifier"));
       device.setDeviceIndex(row.getInt("deviceIndex"));
       device.setDeviceModel(row.getString("deviceModel"));
       device.setDeviceVendor(row.getString("deviceVendor"));
       device.setFormFactor(row.getString("formFactor"));
       device.setLastLatitude(row.getDouble("lastLatitude"));
-      device.setLastLocationTime(row.getDate("lastLocationTime"));
+      device.setLastLocationTime(row.getTimestamp("lastLocationTime"));
       device.setLastLongitude(row.getDouble("lastLongitude"));
-      device.setLastLocationTime(row.getDate("lastLocationTime"));
+      device.setLastLocationTime(row.getTimestamp("lastLocationTime"));
       device.setNotificationToken(row.getString("notificationToken"));
       device.setOsType(row.getString("osType"));
       device.setOsVersion(row.getString("osVersion"));

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/PersonDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/PersonDAOImpl.java
@@ -309,10 +309,10 @@ public class PersonDAOImpl extends BaseCassandraCRUDDao<UUID, Person> implements
       entity.setAccountId(row.getUUID(PersonEntityColumns.ACCOUNT_ID));
       entity.setCurrLocation(row.getString(PersonEntityColumns.CURRENT_LOCATION));
       entity.setCurrLocationMethod(row.getString(PersonEntityColumns.CURRENT_LOCATION_METHOD));
-      entity.setCurrLocationTime(row.getDate(PersonEntityColumns.CURRENT_LOCATION_TIME));
+      entity.setCurrLocationTime(row.getTimestamp(PersonEntityColumns.CURRENT_LOCATION_TIME));
       entity.setCurrPlace(row.getUUID(PersonEntityColumns.CURRENT_PLACE));
       entity.setCurrPlaceMethod(row.getString(PersonEntityColumns.CURRENT_PLACE_METHOD));
-      entity.setEmailVerified(row.getDate(PersonEntityColumns.EMAIL_VERIFIED));
+      entity.setEmailVerified(row.getTimestamp(PersonEntityColumns.EMAIL_VERIFIED));
       entity.setMobileNotificationEndpoints(row.getList(PersonEntityColumns.MOBILE_NOTIFICATION_ENDPOINTS, String.class));
       String mobileNumberStr = row.getString(PersonEntityColumns.MOBILE_NUMBER);
       try {
@@ -325,7 +325,7 @@ public class PersonDAOImpl extends BaseCassandraCRUDDao<UUID, Person> implements
       	//TODO - what do we with existing invalid phone numbers since we have not validated them until now?
       	entity.setMobileNumber(mobileNumberStr);
       }
-      entity.setMobileVerified(row.getDate(PersonEntityColumns.MOBILE_VERIFIED));
+      entity.setMobileVerified(row.getTimestamp(PersonEntityColumns.MOBILE_VERIFIED));
       entity.setFirstName(row.getString(PersonEntityColumns.FIRST_NAME));
       entity.setLastName(row.getString(PersonEntityColumns.LAST_NAME));
 
@@ -356,10 +356,10 @@ public class PersonDAOImpl extends BaseCassandraCRUDDao<UUID, Person> implements
          }
       }
 
-      entity.setTermsAgreed(row.getDate(PersonEntityColumns.TERMS_AGREED));
-      entity.setPrivacyPolicyAgreed(row.getDate(PersonEntityColumns.PRIVACY_POLICY_AGREED));
-      entity.setConsentOffersPromotions(row.getDate(PersonEntityColumns.CONSENT_OFFERSPROMOTIONS));
-      entity.setConsentStatement(row.getDate(PersonEntityColumns.CONSENT_STATEMENT));
+      entity.setTermsAgreed(row.getTimestamp(PersonEntityColumns.TERMS_AGREED));
+      entity.setPrivacyPolicyAgreed(row.getTimestamp(PersonEntityColumns.PRIVACY_POLICY_AGREED));
+      entity.setConsentOffersPromotions(row.getTimestamp(PersonEntityColumns.CONSENT_OFFERSPROMOTIONS));
+      entity.setConsentStatement(row.getTimestamp(PersonEntityColumns.CONSENT_STATEMENT));
 
       Map<String,String> securityAnswers = row.getMap(PersonEntityColumns.SECURITY_ANSWERS, String.class, String.class);
       if(securityAnswers != null && !securityAnswers.isEmpty()) {
@@ -525,7 +525,7 @@ public class PersonDAOImpl extends BaseCassandraCRUDDao<UUID, Person> implements
       login.setPasswordSalt(row.getString(LoginColumns.PASSWORD_SALT));
       login.setUserId(row.getUUID(LoginColumns.USERID));
       login.setUsername(username);
-      login.setLastPasswordChange(row.getDate(LoginColumns.LAST_PASS_CHANGE));
+      login.setLastPasswordChange(row.getTimestamp(LoginColumns.LAST_PASS_CHANGE));
       return login;
    }
 
@@ -708,7 +708,7 @@ public class PersonDAOImpl extends BaseCassandraCRUDDao<UUID, Person> implements
       String password = row.getString(LoginColumns.PASSWORD);
       String password_salt = row.getString(LoginColumns.PASSWORD_SALT);
       UUID userId = row.getUUID(LoginColumns.USERID);
-      Date lastPassChange = row.getDate(LoginColumns.LAST_PASS_CHANGE);
+      Date lastPassChange = row.getTimestamp(LoginColumns.LAST_PASS_CHANGE);
       BoundStatement insert = new BoundStatement(insertLogin)
          .setString(LoginColumns.DOMAIN, newParsedEmail.getDomain())
          .setString(LoginColumns.USER_0_3, newParsedEmail.getUser_0_3())
@@ -718,7 +718,7 @@ public class PersonDAOImpl extends BaseCassandraCRUDDao<UUID, Person> implements
          .setUUID(LoginColumns.USERID, userId)
          // changing the email invalidates the reset token
          .setString(LoginColumns.RESET_TOKEN, null)
-         .setDate(LoginColumns.LAST_PASS_CHANGE, lastPassChange);
+         .setTimestamp(LoginColumns.LAST_PASS_CHANGE, lastPassChange);
 
       Person copy = person.copy();
       copy.setModified(new Date());

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/PlaceDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/PlaceDAOImpl.java
@@ -286,8 +286,8 @@ public class PlaceDAOImpl extends ChangesBaseCassandraCRUDDao<UUID, Place> imple
 
    @Override
    protected void populateEntity(Row row, Place entity) {
-      entity.setCreated(row.getDate(BaseEntityColumns.CREATED));
-      entity.setModified(row.getDate(BaseEntityColumns.MODIFIED));
+      entity.setCreated(row.getTimestamp(BaseEntityColumns.CREATED));
+      entity.setModified(row.getTimestamp(BaseEntityColumns.MODIFIED));
       entity.setAccount(row.getUUID(PlaceEntityColumns.ACCOUNT_ID));
       entity.setName(row.getString(PlaceEntityColumns.NAME));
       entity.setState(row.getString(PlaceEntityColumns.STATE));
@@ -311,7 +311,7 @@ public class PlaceDAOImpl extends ChangesBaseCassandraCRUDDao<UUID, Place> imple
       entity.setAddrRDI(row.getString(PlaceEntityColumns.ADDR_RDI));
       entity.setAddrCounty(row.getString(PlaceEntityColumns.ADDR_COUNTY));
       entity.setAddrCountyFIPS(row.getString(PlaceEntityColumns.ADDR_COUNTY_FIPS));
-      entity.setLastServiceLevelChange(row.getDate(PlaceEntityColumns.LAST_SERVICE_LEVEL_CHANGE));
+      entity.setLastServiceLevelChange(row.getTimestamp(PlaceEntityColumns.LAST_SERVICE_LEVEL_CHANGE));
       String serviceLevel = row.getString(PlaceEntityColumns.SERVICE_LEVEL);
       if(serviceLevel != null) {
          entity.setServiceLevel(ServiceLevel.valueOf(serviceLevel));

--- a/platform/arcus-lib/src/main/java/com/iris/core/protocol/ipcd/cassandra/CassandraIpcdDeviceDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/protocol/ipcd/cassandra/CassandraIpcdDeviceDao.java
@@ -222,9 +222,9 @@ public class CassandraIpcdDeviceDao implements IpcdDeviceDao {
       ipcdDevice.setAccountId(row.getUUID(IpcdDeviceTable.Columns.ACCOUNT_ID));
       ipcdDevice.setPlaceId(row.getUUID(IpcdDeviceTable.Columns.PLACE_ID));
       ipcdDevice.setDriverAddress(row.getString(IpcdDeviceTable.Columns.DRIVER_ADDRESS));
-      ipcdDevice.setCreated(row.getDate(IpcdDeviceTable.Columns.CREATED));
-      ipcdDevice.setModified(row.getDate(IpcdDeviceTable.Columns.MODIFIED));
-      ipcdDevice.setLastConnected(row.getDate(IpcdDeviceTable.Columns.LAST_CONNECTED));
+      ipcdDevice.setCreated(row.getTimestamp(IpcdDeviceTable.Columns.CREATED));
+      ipcdDevice.setModified(row.getTimestamp(IpcdDeviceTable.Columns.MODIFIED));
+      ipcdDevice.setLastConnected(row.getTimestamp(IpcdDeviceTable.Columns.LAST_CONNECTED));
       ipcdDevice.setVendor(row.getString(IpcdDeviceTable.Columns.VENDOR));
       ipcdDevice.setModel(row.getString(IpcdDeviceTable.Columns.MODEL));
       ipcdDevice.setSn(row.getString(IpcdDeviceTable.Columns.SN));

--- a/platform/arcus-lib/src/main/java/com/iris/platform/alarm/incident/CassandraAlarmIncidentDAO.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/alarm/incident/CassandraAlarmIncidentDAO.java
@@ -169,8 +169,8 @@ public class CassandraAlarmIncidentDAO implements AlarmIncidentDAO {
       bound.setSet(Column.additionalalerts.name(), incident.getAdditionalAlerts().stream().map(AlertType::name).collect(Collectors.toSet()));
       bound.setString(Column.alert.name(), incident.getAlert().name());
       bound.setString(Column.cancelledby.name(), incident.getCancelledBy() == null ? null : incident.getCancelledBy().getRepresentation());
-      bound.setDate(Column.prealertendtime.name(), incident.getPrealertEndTime());
-      bound.setDate(Column.endtime.name(), incident.getEndTime());
+      bound.setTimestamp(Column.prealertendtime.name(), incident.getPrealertEndTime());
+      bound.setTimestamp(Column.endtime.name(), incident.getEndTime());
       bound.setString(Column.monitoringstate.name(), incident.getMonitoringState().name());
       bound.setList(Column.tracker.name(), incident.getTracker().stream().map((te) -> JSON.toJson(te.toMap())).collect(Collectors.toList()));
       bound.setBool(Column.mockincident.name(), incident.isMockIncident());
@@ -215,8 +215,8 @@ public class CassandraAlarmIncidentDAO implements AlarmIncidentDAO {
             .withMonitoringState(AlarmIncident.MonitoringState.valueOf(r.getString(Column.monitoringstate.name())))
             .withId(r.getUUID(Column.incidentid.name()))
             .withAlertState(AlarmIncident.AlertState.valueOf(r.getString(Column.alertstate.name())))
-            .withPrealertEndTime(r.getDate(Column.prealertendtime.name()))
-            .withEndTime(r.getDate(Column.endtime.name()))
+            .withPrealertEndTime(r.getTimestamp(Column.prealertendtime.name()))
+            .withEndTime(r.getTimestamp(Column.endtime.name()))
             .withPlaceId(r.getUUID(Column.placeid.name()))
             .withMonitored(r.getBool(Column.monitored.name()))
             .withMockIncident(r.getBool(Column.mockincident.name()))

--- a/platform/arcus-lib/src/main/java/com/iris/platform/cluster/cassandra/CassandraClusterServiceDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/cluster/cassandra/CassandraClusterServiceDao.java
@@ -265,11 +265,11 @@ public class CassandraClusterServiceDao implements ClusterServiceDao {
       record.setHost(row.getString(ClusterServiceTable.Columns.HOST));
       record.setService(row.getString(ClusterServiceTable.Columns.SERVICE));
       record.setMemberId(row.getInt(ClusterServiceTable.Columns.CLUSTER_ID));
-      Date registered = row.getDate(ClusterServiceTable.Columns.REGISTERED);
+      Date registered = row.getTimestamp(ClusterServiceTable.Columns.REGISTERED);
       if(registered != null) {
          record.setRegistered(registered.toInstant());
       }
-      Date heartbeat = row.getDate(ClusterServiceTable.Columns.HEARTBEAT);
+      Date heartbeat = row.getTimestamp(ClusterServiceTable.Columns.HEARTBEAT);
       if(heartbeat != null) {
          record.setLastHeartbeat(heartbeat.toInstant());
       }

--- a/platform/arcus-lib/src/main/java/com/iris/platform/history/cassandra/CassandraActivityDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/history/cassandra/CassandraActivityDao.java
@@ -170,7 +170,7 @@ public class CassandraActivityDao implements HistoryActivityDAO {
 	
 	protected ActivityEvent transform(Row row) {
 		ActivityEvent event = new ActivityEvent();
-		event.setTimestamp(row.getDate(Columns.TIME));
+		event.setTimestamp(row.getTimestamp(Columns.TIME));
 		event.setPlaceId(row.getUUID(Columns.PLACE_ID));
 		event.setActiveDevices(row.getSet(Columns.ACTIVE_DEVICES, String.class));
 		event.setInactiveDevices(row.getSet(Columns.DEACTIVATED_DEVICES, String.class));

--- a/platform/arcus-lib/src/main/java/com/iris/platform/pairing/cassandra/CassandraPairingDeviceDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/pairing/cassandra/CassandraPairingDeviceDao.java
@@ -238,8 +238,8 @@ public class CassandraPairingDeviceDao extends BaseModelDao<PairingDevice> imple
       PairingDevice entity = attributes.containsKey(PairingDeviceMockCapability.ATTR_TARGETPRODUCTADDRESS) ? new PairingDeviceMock(attributes) : new PairingDevice(attributes);
       entity.setId( row.getUUID(PairingDeviceTable.Column.placeId.name()), row.getInt(PairingDeviceTable.Column.sequenceId.name()) );
       entity.setProtocolAddress( (DeviceProtocolAddress) Address.fromString( row.getString(PairingDeviceTable.Column.protocolAddress.name()) ) );
-      entity.setModified( row.getDate(PairingDeviceTable.Column.modified.name()) );
-      entity.setCreated( row.getDate(PairingDeviceTable.Column.created.name()) );
+      entity.setModified( row.getTimestamp(PairingDeviceTable.Column.modified.name()) );
+      entity.setCreated( row.getTimestamp(PairingDeviceTable.Column.created.name()) );
       entity.setPopulation(populationCacheMgr.getPopulationByPlaceId(entity.getPlaceId()));
       return entity;
    }

--- a/platform/arcus-lib/src/main/java/com/iris/platform/rule/cassandra/ActionDaoImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/rule/cassandra/ActionDaoImpl.java
@@ -91,9 +91,9 @@ public class ActionDaoImpl
       ActionDefinition ad = new ActionDefinition();
       ad.setPlaceId(row.getUUID(Column.PLACE_ID.columnName()));
       ad.setSequenceId(row.getInt(Column.ID.columnName()));
-      ad.setCreated(row.getDate(Column.CREATED.columnName()));
-      ad.setModified(row.getDate(Column.MODIFIED.columnName()));
-      ad.setLastExecuted(row.getDate(ActionColumn.LAST_EXECUTED.columnName()));
+      ad.setCreated(row.getTimestamp(Column.CREATED.columnName()));
+      ad.setModified(row.getTimestamp(Column.MODIFIED.columnName()));
+      ad.setLastExecuted(row.getTimestamp(ActionColumn.LAST_EXECUTED.columnName()));
       ad.setName(row.getString(Column.NAME.columnName()));
       ad.setDescription(row.getString(Column.DESCRIPTION.columnName()));
       ad.setTags(row.getSet(Column.TAGS.columnName(), String.class));
@@ -112,8 +112,8 @@ public class ActionDaoImpl
       BoundStatement bs = upsert.bind();
       bs.setUUID(Column.PLACE_ID.columnName(), ad.getPlaceId());
       bs.setInt(Column.ID.columnName(), ad.getSequenceId());
-      bs.setDate(Column.CREATED.columnName(), ad.getCreated());
-      bs.setDate(Column.MODIFIED.columnName(), ad.getModified());
+      bs.setTimestamp(Column.CREATED.columnName(), ad.getCreated());
+      bs.setTimestamp(Column.MODIFIED.columnName(), ad.getModified());
       bs.setString(Column.NAME.columnName(), ad.getName());
       bs.setString(Column.DESCRIPTION.columnName(), ad.getDescription());
       bs.setSet(Column.TAGS.columnName(), ad.getTags());

--- a/platform/arcus-lib/src/main/java/com/iris/platform/rule/cassandra/RuleDaoImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/rule/cassandra/RuleDaoImpl.java
@@ -128,8 +128,8 @@ public class RuleDaoImpl
 
       definition.setPlaceId(row.getUUID(Column.PLACE_ID.columnName()));
       definition.setSequenceId(row.getInt(Column.ID.columnName()));
-      definition.setCreated(row.getDate(Column.CREATED.columnName()));
-      definition.setModified(row.getDate(Column.MODIFIED.columnName()));
+      definition.setCreated(row.getTimestamp(Column.CREATED.columnName()));
+      definition.setModified(row.getTimestamp(Column.MODIFIED.columnName()));
       definition.setName(row.getString(Column.NAME.columnName()));
       definition.setDescription(row.getString(Column.DESCRIPTION.columnName()));
       definition.setTags(row.getSet(Column.TAGS.columnName(), String.class));
@@ -159,8 +159,8 @@ public class RuleDaoImpl
       BoundStatement bs = upsert.bind();
       bs.setUUID(Column.PLACE_ID.columnName(), definition.getPlaceId());
       bs.setInt(Column.ID.columnName(), definition.getSequenceId());
-      bs.setDate(Column.CREATED.columnName(), definition.getCreated());
-      bs.setDate(Column.MODIFIED.columnName(), definition.getModified());
+      bs.setTimestamp(Column.CREATED.columnName(), definition.getCreated());
+      bs.setTimestamp(Column.MODIFIED.columnName(), definition.getModified());
       bs.setString(Column.NAME.columnName(), definition.getName());
       bs.setString(Column.DESCRIPTION.columnName(), definition.getDescription());
       bs.setSet(Column.TAGS.columnName(), definition.getTags());
@@ -191,7 +191,7 @@ public class RuleDaoImpl
       bs.setUUID(Column.PLACE_ID.columnName(), id.getPrimaryId());
       bs.setInt(Column.ID.columnName(), id.getSecondaryId());
       bs.setString(RuleColumn.VARIABLES.columnName(), JSON.toJson(variables));
-      bs.setDate(Column.MODIFIED.columnName(),modified);
+      bs.setTimestamp(Column.MODIFIED.columnName(),modified);
       ResultSet rs = session.execute(bs);
       if(!rs.wasApplied()) {
          throw new IllegalStateException(String.format("Unable to update rule variables. Rule [%s] has been modified since read",id));

--- a/platform/arcus-lib/src/main/java/com/iris/platform/rule/cassandra/SceneDaoImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/rule/cassandra/SceneDaoImpl.java
@@ -79,13 +79,13 @@ public class SceneDaoImpl extends BaseRuleEnvironmentDaoImpl<SceneDefinition> im
       SceneDefinition sd = new SceneDefinition();
       sd.setPlaceId(row.getUUID(Column.PLACE_ID.columnName()));
       sd.setSequenceId(row.getInt(Column.ID.columnName()));
-      sd.setCreated(row.getDate(Column.CREATED.columnName()));
-      sd.setModified(row.getDate(Column.MODIFIED.columnName()));
+      sd.setCreated(row.getTimestamp(Column.CREATED.columnName()));
+      sd.setModified(row.getTimestamp(Column.MODIFIED.columnName()));
       sd.setName(row.getString(Column.NAME.columnName()));
       sd.setDescription(row.getString(Column.DESCRIPTION.columnName()));
       sd.setTags(row.getSet(Column.TAGS.columnName(), String.class));
       sd.setLastFireState(row.getString(SceneColumn.LAST_FIRE_STATE.columnName()));
-      sd.setLastFireTime(row.getDate(SceneColumn.LAST_FIRE_TIME.columnName()));
+      sd.setLastFireTime(row.getTimestamp(SceneColumn.LAST_FIRE_TIME.columnName()));
       sd.setSatisfiable(row.getBool(SceneColumn.SATISFIABLE.columnName()));
       sd.setNotification(row.getBool(SceneColumn.NOTIFICATION.columnName()));
       sd.setTemplate(row.getString(SceneColumn.TEMPLATE.columnName()));
@@ -103,15 +103,15 @@ public class SceneDaoImpl extends BaseRuleEnvironmentDaoImpl<SceneDefinition> im
       BoundStatement bs = upsert.bind();
       bs.setUUID(Column.PLACE_ID.columnName(), sd.getPlaceId());
       bs.setInt(Column.ID.columnName(), sd.getSequenceId());
-      bs.setDate(Column.CREATED.columnName(), sd.getCreated());
-      bs.setDate(Column.MODIFIED.columnName(), sd.getModified());
+      bs.setTimestamp(Column.CREATED.columnName(), sd.getCreated());
+      bs.setTimestamp(Column.MODIFIED.columnName(), sd.getModified());
       bs.setString(Column.NAME.columnName(), sd.getName());
       bs.setString(Column.DESCRIPTION.columnName(), sd.getDescription());
       bs.setSet(Column.TAGS.columnName(), sd.getTags());
       bs.setString(SceneColumn.TEMPLATE.columnName(), sd.getTemplate());
       bs.setBool(SceneColumn.SATISFIABLE.columnName(), sd.isSatisfiable());
       bs.setBool(SceneColumn.NOTIFICATION.columnName(), sd.isNotification());
-      bs.setDate(SceneColumn.LAST_FIRE_TIME.columnName(), sd.getLastFireTime());
+      bs.setTimestamp(SceneColumn.LAST_FIRE_TIME.columnName(), sd.getLastFireTime());
       bs.setString(SceneColumn.LAST_FIRE_STATE.columnName(), sd.getLastFireState());
       bs.setBool(SceneColumn.ENABLED.columnName(),sd.isEnabled());
 

--- a/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraScheduleDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraScheduleDao.java
@@ -213,8 +213,8 @@ public class CassandraScheduleDao implements ScheduleDao {
 
       BoundStatement statement = upsertCommand.bind();
       statement.setInt(ScheduledEventTable.Columns.PARTITION_ID, offset.getPartition().getId());
-      statement.setDate(ScheduledEventTable.Columns.TIME_BUCKET, offset.getOffset());
-      statement.setDate(ScheduledEventTable.Columns.SCHEDULED_TIME, scheduledTime);
+      statement.setTimestamp(ScheduledEventTable.Columns.TIME_BUCKET, offset.getOffset());
+      statement.setTimestamp(ScheduledEventTable.Columns.SCHEDULED_TIME, scheduledTime);
       statement.setUUID(ScheduledEventTable.Columns.PLACE_ID, placeId);
       statement.setString(ScheduledEventTable.Columns.SCHEDULER, schedulerAddress.getRepresentation());
 
@@ -269,7 +269,7 @@ public class CassandraScheduleDao implements ScheduleDao {
       PlatformPartition partition = partitioner.getPartitionById(row.getInt(SchedulerOffsetTable.Columns.PARTITION_ID));
       PartitionOffset offset = new PartitionOffset(
             partition,
-            row.getDate(SchedulerOffsetTable.Columns.LAST_EXECUTED_BUCKET),
+            row.getTimestamp(SchedulerOffsetTable.Columns.LAST_EXECUTED_BUCKET),
             windowSizeMs
       );
       return offset;
@@ -279,14 +279,14 @@ public class CassandraScheduleDao implements ScheduleDao {
       try {
          ScheduledCommand command = new ScheduledCommand();
          command.setPlaceId(row.getUUID(ScheduledEventTable.Columns.PLACE_ID));
-         command.setScheduledTime(row.getDate(ScheduledEventTable.Columns.SCHEDULED_TIME));
+         command.setScheduledTime(row.getTimestamp(ScheduledEventTable.Columns.SCHEDULED_TIME));
          command.setSchedulerAddress(Address.fromString(row.getString(ScheduledEventTable.Columns.SCHEDULER)));
-         command.setExpirationTime(row.getDate(ScheduledEventTable.Columns.EXPIRES_AT));
+         command.setExpirationTime(row.getTimestamp(ScheduledEventTable.Columns.EXPIRES_AT));
 
          PlatformPartition partition = partitioner.getPartitionById(row.getInt(SchedulerOffsetTable.Columns.PARTITION_ID));
          PartitionOffset offset = new PartitionOffset(
                partition,
-               row.getDate(ScheduledEventTable.Columns.TIME_BUCKET),
+               row.getTimestamp(ScheduledEventTable.Columns.TIME_BUCKET),
                windowSizeMs
          );
          command.setOffset(offset);

--- a/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraSchedulerModelDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraSchedulerModelDao.java
@@ -387,8 +387,8 @@ public class CassandraSchedulerModelDao extends BaseModelDao implements Schedule
    protected ModelEntity toModel(Row row, boolean includeWeekdays) {
       Map<String, String> attributes = row.getMap(Columns.ATTRIBUTES, String.class, String.class);
       ModelEntity model = new ModelEntity( decode( attributes ) );
-      model.setCreated( row.getDate(Columns.CREATED) );
-      model.setModified( row.getDate(Columns.MODIFIED) );
+      model.setCreated( row.getTimestamp(Columns.CREATED) );
+      model.setModified( row.getTimestamp(Columns.MODIFIED) );
       if(!includeWeekdays && model.getInstances() != null) {
     	  //Remove WeeklyScheduleCapability instance data to reduce size of the model
     	  Map<String, Set<String>> instances = model.getInstances();

--- a/platform/arcus-lib/src/main/java/com/iris/platform/subsystem/cassandra/CassandraSubsystemDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/subsystem/cassandra/CassandraSubsystemDao.java
@@ -248,8 +248,8 @@ public class CassandraSubsystemDao extends BaseModelDao implements SubsystemDao 
    protected ModelEntity toModel(Row row) {
       Map<String, String> attributes = row.getMap(Columns.ATTRIBUTES, String.class, String.class);
       ModelEntity model = new ModelEntity( decode( attributes ) );
-      model.setCreated( row.getDate(Columns.CREATED) );
-      model.setModified( row.getDate(Columns.MODIFIED) );
+      model.setCreated( row.getTimestamp(Columns.CREATED) );
+      model.setModified( row.getTimestamp(Columns.MODIFIED) );
       return model;
    }
 

--- a/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/changelog/dao/ChangeSetDAO.java
+++ b/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/changelog/dao/ChangeSetDAO.java
@@ -93,7 +93,7 @@ public class ChangeSetDAO {
       cs.setIdentifier(row.getString("identifier"));
       cs.setSource(row.getString("source"));
       cs.setStatus(Status.valueOf(row.getString("status")));
-      cs.setTimestamp(row.getDate("timestamp"));
+      cs.setTimestamp(row.getTimestamp("timestamp"));
       cs.setTracking(row.getString("tracking"));
       cs.setVersion(row.getString("version"));
       return cs;

--- a/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/commands/SetPrimaryPlace.java
+++ b/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/commands/SetPrimaryPlace.java
@@ -38,7 +38,7 @@ public class SetPrimaryPlace implements ExecutionCommand {
       PreparedStatement stmt = context.getSession().prepare(update);
 
       List<Row> rows = context.getSession().execute("SELECT id, accountid, created FROM place").all();
-      List<Row> ordered = rows.stream().sorted((r1, r2) -> r1.getDate("created").compareTo(r2.getDate("created"))).collect(Collectors.toList());
+      List<Row> ordered = rows.stream().sorted((r1, r2) -> r1.getTimestamp("created").compareTo(r2.getTimestamp("created"))).collect(Collectors.toList());
       Set<UUID> accountsSeen = new HashSet<>();
 
       BatchStatement batch = new BatchStatement();

--- a/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/commands/UpdateAccountTrialEnd.java
+++ b/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/commands/UpdateAccountTrialEnd.java
@@ -39,7 +39,7 @@ public class UpdateAccountTrialEnd implements ExecutionCommand {
       BatchStatement batch = new BatchStatement();
       rows.forEach((r) -> {
          batch.add(new BoundStatement(stmt)
-         .setDate("trialEnd", new Date(r.getDate("created").getTime() + TRIAL_MS))
+         .setTimestamp("trialEnd", new Date(r.getTimestamp("created").getTime() + TRIAL_MS))
          .setUUID("id", r.getUUID("id")));
       });
       context.getSession().execute(batch);

--- a/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/version/dao/VersionHistoryDAO.java
+++ b/platform/arcus-modelmanager/src/main/java/com/iris/modelmanager/version/dao/VersionHistoryDAO.java
@@ -75,7 +75,7 @@ public class VersionHistoryDAO {
    private VersionHistory buildVersionHistory(Row row) {
       VersionHistory history = new VersionHistory();
       history.setStatus(Status.valueOf(row.getString("status")));
-      history.setTimestamp(row.getDate("timestamp"));
+      history.setTimestamp(row.getTimestamp("timestamp"));
       history.setUsername(row.getString("username"));
       history.setVersion(row.getString("version"));
       return history;

--- a/platform/arcus-security/src/main/java/com/iris/security/GuicedCassandraSessionDAO.java
+++ b/platform/arcus-security/src/main/java/com/iris/security/GuicedCassandraSessionDAO.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.time.ZoneId;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.ShiroException;
@@ -308,7 +309,7 @@ public class GuicedCassandraSessionDAO extends AbstractSessionDAO implements Ini
 	private Session hydrateSession(UUID id, Row row) {
    	UUID rowId = row.getUUID(Columns.ID);
    	if (id.equals(rowId)) {
-   		Date start = row.getDate(Columns.START);
+   		Date start = row.getTimestamp(Columns.START);
    		// If this is null, then the row is a tombstone.
    		if (start != null) {
    			ByteBuffer buffer = row.getBytes(Columns.SERIALIZED);
@@ -320,8 +321,8 @@ public class GuicedCassandraSessionDAO extends AbstractSessionDAO implements Ini
    			}
    			else {
    				// New style session. Read the fields and create a session.
-   				Date stop = row.getDate(Columns.STOP);
-   				Date lastAccess = row.getDate(Columns.LAST_ACCESS);
+                Date stop = row.getTimestamp(Columns.STOP);
+                Date lastAccess = row.getTimestamp(Columns.LAST_ACCESS);
    				long timeout = row.getLong(Columns.TIMEOUT);
    				boolean expired = row.getBool(Columns.EXPIRED);
    				String host = row.getString(Columns.HOST);

--- a/platform/arcus-video/src/main/java/com/iris/video/VideoUtil.java
+++ b/platform/arcus-video/src/main/java/com/iris/video/VideoUtil.java
@@ -49,6 +49,7 @@ import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TypeCodec;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
@@ -459,51 +460,51 @@ public final class VideoUtil {
 	/////////////////////////////////////////////////////////////////////////////
 
 	public static ByteBuffer toblob(String value) {
-		return DataType.text().serialize(value, ProtocolVersion.V3);
+		return TypeCodec.varchar().serialize(value, ProtocolVersion.V3);
 	}
 
 	public static ByteBuffer toblob(UUID value) {
-		return DataType.uuid().serialize(value, ProtocolVersion.V3);
+		return TypeCodec.uuid().serialize(value, ProtocolVersion.V3);
 	}
 
 	public static ByteBuffer toblob(int value) {
-		return DataType.cint().serialize(value, ProtocolVersion.V3);
+		return TypeCodec.cint().serialize(value, ProtocolVersion.V3);
 	}
 
 	public static ByteBuffer toblob(long value) {
-		return DataType.bigint().serialize(value, ProtocolVersion.V3);
+		return TypeCodec.bigint().serialize(value, ProtocolVersion.V3);
 	}
 	
 	public static ByteBuffer toblob(Date value) {
-		return DataType.timestamp().serialize(value, ProtocolVersion.V3);
+		return TypeCodec.timestamp().serialize(value, ProtocolVersion.V3);
 	}
 
 	public static ByteBuffer toblob(double value) {
-		return DataType.cdouble().serialize(value, ProtocolVersion.V3);
+		return TypeCodec.cdouble().serialize(value, ProtocolVersion.V3);
 	}
 
 	public static String tostr(ByteBuffer value) {
-		return (String) DataType.text().deserialize(value, ProtocolVersion.V3);
+		return (String) TypeCodec.varchar().deserialize(value, ProtocolVersion.V3);
 	}
 
 	public static UUID touuid(ByteBuffer value) {
-		return (UUID) DataType.uuid().deserialize(value, ProtocolVersion.V3);
+		return (UUID) TypeCodec.uuid().deserialize(value, ProtocolVersion.V3);
 	}
 
 	public static int toint(ByteBuffer value) {
-		return (int) DataType.cint().deserialize(value, ProtocolVersion.V3);
+		return (int) TypeCodec.cint().deserialize(value, ProtocolVersion.V3);
 	}
 
 	public static long tolong(ByteBuffer value) {
-		return (long) DataType.bigint().deserialize(value, ProtocolVersion.V3);
+		return (long) TypeCodec.bigint().deserialize(value, ProtocolVersion.V3);
 	}
 
 	public static double todouble(ByteBuffer value) {
-		return (double) DataType.cdouble().deserialize(value, ProtocolVersion.V3);
+		return (double) TypeCodec.cdouble().deserialize(value, ProtocolVersion.V3);
 	}
 	
 	public static Date toDate(ByteBuffer value) {
-		return (Date) DataType.timestamp().deserialize(value, ProtocolVersion.V3);
+		return (Date) TypeCodec.timestamp().deserialize(value, ProtocolVersion.V3);
 	}
 
 	public static ByteBuffer toblob(Enum<?> e) {

--- a/platform/arcus-video/src/main/java/com/iris/video/cql/v2/PlacePurgeRecordingTable.java
+++ b/platform/arcus-video/src/main/java/com/iris/video/cql/v2/PlacePurgeRecordingTable.java
@@ -106,7 +106,7 @@ public class PlacePurgeRecordingTable extends VideoTable {
 		if(!row.isNull(COL_MODE)) {
 			mode = PurgeMode.valueOf(row.getString(COL_MODE));
 		}
-		return new PlacePurgeRecord(row.getUUID(COL_PLACEID), row.getDate(COL_DELETE_TIME), mode);
+		return new PlacePurgeRecord(row.getUUID(COL_PLACEID), row.getTimestamp(COL_DELETE_TIME), mode);
 		
 	}
 }

--- a/platform/arcus-video/src/main/java/com/iris/video/cql/v2/PurgeRecordingV2Table.java
+++ b/platform/arcus-video/src/main/java/com/iris/video/cql/v2/PurgeRecordingV2Table.java
@@ -94,7 +94,7 @@ public class PurgeRecordingV2Table extends AbstractPurgeRecordingTable {
 			storageStr = storageStr.substring(0, storageStr.length()-2);
 			purgePreview = true;
 		}
-		return new PurgeRecord(row.getDate(COL_DELETETIME), row.getInt(COL_PARTITIONID), row.getUUID(COL_RECORDINGID), row.getUUID(COL_PLACEID), storageStr, true, purgePreview);
+		return new PurgeRecord(row.getTimestamp(COL_DELETETIME), row.getInt(COL_PARTITIONID), row.getUUID(COL_RECORDINGID), row.getUUID(COL_PLACEID), storageStr, true, purgePreview);
 	}
 
 	@Override


### PR DESCRIPTION
This revision adds support for cassandra 3.x by adding an appropriate query for determining whether a keyspace exists on cassandra 3.x. A future version will bump the cassandra version to 3.x once it's determined to be stable.