### PR TITLE
Rename "Iris" to "Arcus" in push notification templates

### DIFF
--- a/platform/arcus-containers/notification-services/src/dist/templates/account.email.changed-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/account.email.changed-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title'      : "Email changed",
-    'message'    : "The email address associated with your Iris account was recently changed from {{{oldemail}}} to {{{_person.email}}}.",
+    'message'    : "The email address associated with your Arcus account was recently changed from {{{oldemail}}} to {{{_person.email}}}.",
     'importance' : "IMPORTANCE_DEFAULT",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/account.email.verify-email.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/account.email.verify-email.hbs
@@ -5,7 +5,7 @@ Confirm Your Email
 {{#section "plaintext-body"}}
 Hi {{{_person.firstName}}},
 
-We are glad you are here. Confirm your email address below to activate your Iris account. Click Here to Verify Email {{{_webHomeBaseUrl}}}/login/{{{platform}}}?token={{{emailVerificationToken}}}&email={{{urlEncode _person.email}}}
+We are glad you are here. Confirm your email address below to activate your Arcus account. Click Here to Verify Email {{{_webHomeBaseUrl}}}/login/{{{platform}}}?token={{{emailVerificationToken}}}&email={{{urlEncode _person.email}}}
 {{/section}}
 
 {{#section "html-body"}}
@@ -15,7 +15,7 @@ We are glad you are here. Confirm your email address below to activate your Iris
 	{{/partial}}
 
 	{{#partial "message" }}
-	<p>We are glad you are here. Confirm your email address below to activate your Iris account.</p>
+	<p>We are glad you are here. Confirm your email address below to activate your Arcus account.</p>
     <table align="center" cellpadding="0" cellspacing="0">
                   <tr>
                     <td align="center" height="44" style="background-color: #00bfb3 ; background-image: linear-gradient(to right, #00bfb3 , #0095c8 ); border-radius: 6px; padding-left:20px; padding-right:20px; font-family: Arial, Helvetica, sans-serif; font-size:15px; color: #ffffff " width="100%"><a href="{{_webHomeBaseUrl}}/login/{{platform}}?token={{emailVerificationToken}}&email={{urlEncode _person.email}}" style="text-decoration: none; color: #ffffff ;" target="_blank">Click Here to Verify Email</a></td>

--- a/platform/arcus-containers/notification-services/src/dist/templates/account.person.invited.cancelled.notify.invitee-email.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/account.person.invited.cancelled.notify.invitee-email.hbs
@@ -1,5 +1,5 @@
 {{#section "subject"}}
-Your Iris Invitation To {{{_owner.firstName}}} {{{_owner.lastName}}}'s Place Was Cancelled.
+Your Arcus Invitation To {{{_owner.firstName}}} {{{_owner.lastName}}}'s Place Was Cancelled.
 {{/section}}
 
 {{#section "plaintext-body"}}

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.dispatch.refused-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.dispatch.refused-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details."
+    "body": "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details."
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.dispatch.refused-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.dispatch.refused-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "CO Alarm",
-    'message': "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details.",
+    'message': "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details.",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.triggered.pro-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.triggered.pro-apns.hbs
@@ -1,3 +1,3 @@
 {
-  "body" : "CO detected by {{{deviceName}}} at {{{_place.name}}}.  Immediately move everyone to fresh air. Moving outside is the safest solution. Iris is attempting to dispatch the Fire Dept."
+  "body" : "CO detected by {{{deviceName}}} at {{{_place.name}}}.  Immediately move everyone to fresh air. Moving outside is the safest solution. Arcus is attempting to dispatch the Fire Dept."
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.triggered.pro-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.co.triggered.pro-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title'      : 'CO Alarm Triggered',
-    'message'    : "by {{{deviceName}}} at {{{_place.name}}}.  Immediately move everyone to fresh air. Moving outside is the safest solution. Iris is attempting to dispatch the Fire Dept.",
+    'message'    : "by {{{deviceName}}} at {{{_place.name}}}.  Immediately move everyone to fresh air. Moving outside is the safest solution. Arcus is attempting to dispatch the Fire Dept.",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.panic.dispatch.refused-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.panic.dispatch.refused-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details."
+    "body": "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details."
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.panic.dispatch.refused-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.panic.dispatch.refused-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Panic Alarm",
-    'message': "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details.",
+    'message': "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details.",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.security.dispatch.refused-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.security.dispatch.refused-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details. "
+    "body": "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details. "
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.security.dispatch.refused-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.security.dispatch.refused-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Security Alarm",
-    'message': "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details. ",
+    'message': "An attempt to dispatch the Police to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details. ",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.smoke.dispatch.refused-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.smoke.dispatch.refused-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details."
+    "body": "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details."
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/alarm.smoke.dispatch.refused-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/alarm.smoke.dispatch.refused-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Smoke Alarm",
-    'message': "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Iris app for details.",
+    'message': "An attempt to dispatch the Fire Dept. to {{{_place.name}}} was made, but they declined to respond. Check the Arcus app for details.",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.offline-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.offline-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "The hub at {{{_place.name}}} lost connection to the Iris cloud platform on {{{offlineTime}}}"
+    "body": "The hub at {{{_place.name}}} lost connection to the Arcus cloud platform on {{{offlineTime}}}"
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.offline-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.offline-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Hub lost connection",
-    'message': "The hub at {{{_place.name}}} lost connection to the Iris cloud platform on {{{offlineTime}}}.",
+    'message': "The hub at {{{_place.name}}} lost connection to the Arcus cloud platform on {{{offlineTime}}}.",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.online-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.online-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "The hub at {{{_place.name}}} has reconnected to the Iris cloud platform"
+    "body": "The hub at {{{_place.name}}} has reconnected to the Arcus cloud platform"
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.online-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.online-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Hub reconnected",
-    'message': "The hub at {{{_place.name}}} has reconnected to the Iris cloud platform",
+    'message': "The hub at {{{_place.name}}} has reconnected to the Arcus cloud platform",
     'importance' : "IMPORTANCE_DEFAULT",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "The hub at {{{_place.name}}} has reconnected to the Iris cloud platform, but your Security Alarm was set to Off while the hub was offline"
+    "body": "The hub at {{{_place.name}}} has reconnected to the Arcus cloud platform, but your Security Alarm was set to Off while the hub was offline"
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Hub reconnected",
-    'message': "The hub at {{{_place.name}}} has reconnected to the Iris cloud platform, but your Security Alarm was set to Off while the hub was offline",
+    'message': "The hub at {{{_place.name}}} has reconnected to the Arcus cloud platform, but your Security Alarm was set to Off while the hub was offline",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed.incident-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed.incident-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "The hub at {{{_place.name}}} has reconnected to the Iris cloud platform, but your Security Alarm was set to Off while the hub was offline during an alarm"
+    "body": "The hub at {{{_place.name}}} has reconnected to the Arcus cloud platform, but your Security Alarm was set to Off while the hub was offline during an alarm"
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed.incident-gcm.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.online.disarmed.incident-gcm.hbs
@@ -1,6 +1,6 @@
 {
     'title': "Hub reconnected",
-    'message': "The hub at {{{_place.name}}} has reconnected to the Iris cloud platform, but your Security Alarm was set to Off while the hub was offline during an alarm",
+    'message': "The hub at {{{_place.name}}} has reconnected to the Arcus cloud platform, but your Security Alarm was set to Off while the hub was offline during an alarm",
     'importance' : "IMPORTANCE_HIGH",
     'vibrate'    : 1,
     'sound'      : 1

--- a/platform/arcus-containers/notification-services/src/dist/templates/hub.power.mains-apns.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/hub.power.mains-apns.hbs
@@ -1,3 +1,3 @@
 {
-    "body": "The power to the Iris smart hub at {{{_owner.firstName}}} {{{_owner.lastName}}}'s place ({{{_place.name}}}) has been restored."
+    "body": "The power to the Arcus smart hub at {{{_owner.firstName}}} {{{_owner.lastName}}}'s place ({{{_place.name}}}) has been restored."
 }

--- a/platform/arcus-containers/notification-services/src/dist/templates/logout.touch.failed-email.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/logout.touch.failed-email.hbs
@@ -5,7 +5,7 @@ Invalid Identification Scan
 {{#section "plaintext-body"}}
 Hi {{{_person.firstName}}},
 
-There have been multiple failed attempts to login into Iris using your biometric information -- 
+There have been multiple failed attempts to login into Arcus using your biometric information -- 
 i.e. fingerprint or face identification -- on the following device:
 
 {{{osType}}} {{{osVersion}}}
@@ -22,7 +22,7 @@ For security reasons, you will need to login using your Email and Password.
 	{{/partial}}
 
 	{{#partial "message" }}
-	<p>There have been multiple failed attempts to login into Iris using your biometric information -- i.e. fingerprint or face identification -- on the following device:</p>
+	<p>There have been multiple failed attempts to login into Arcus using your biometric information -- i.e. fingerprint or face identification -- on the following device:</p>
 	<p/>
 	<p>{{osType}} {{osVersion}}</p>
     <p>Device Type: {{deviceVendor}} {{deviceModel}}</p>

--- a/platform/arcus-containers/notification-services/src/dist/templates/rule.c117e7.stop.water.leak-email.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/rule.c117e7.stop.water.leak-email.hbs
@@ -8,7 +8,7 @@
 Hi {{{_person.firstName}}},
 
 {{{ leakh2o }}} has detected a water leak at {{{_place.name}}} and is attempting to turn off {{{ valve }}}.
-Please check the Iris app to ensure the {{{ valve }}} successfully turned it off.
+Please check the Arcus app to ensure the {{{ valve }}} successfully turned it off.
 {{/partial}}
 {{> layout-standard-plaintext-email}}
 {{/section}}
@@ -21,7 +21,7 @@ Please check the Iris app to ensure the {{{ valve }}} successfully turned it off
 
 	{{#partial "message" }}
 	{{ leakh2o }} has detected a water leak at {{_place.name}} and is attempting to turn off {{ valve }}.
-Please check the Iris app to ensure the {{ valve }} successfully turned off.
+Please check the Arcus app to ensure the {{ valve }} successfully turned off.
 	{{/partial}}
 
 	{{#partial "extra" }}{{/partial}}

--- a/platform/arcus-containers/notification-services/src/dist/templates/rule.d6a735.lock.door.sec.on-email.hbs
+++ b/platform/arcus-containers/notification-services/src/dist/templates/rule.d6a735.lock.door.sec.on-email.hbs
@@ -7,7 +7,7 @@
 
 Hi {{{_person.firstName}}},
 
-A door is unlocked and the security alarm is armed at {{{place_name}}}.  Iris is attempting to automatically lock this door. Please check the Iris app to ensure all doors have successfully locked.
+A door is unlocked and the security alarm is armed at {{{place_name}}}.  Arcus is attempting to automatically lock this door. Please check the Arcus app to ensure all doors have successfully locked.
 
 {{/partial}}
 {{> layout-standard-plaintext-email}}
@@ -20,7 +20,7 @@ A door is unlocked and the security alarm is armed at {{{place_name}}}.  Iris is
 	{{/partial}}
 
 	{{#partial "message" }}
-	A door is unlocked and the security alarm is armed at {{_place_name}}.  Iris is attempting to automatically lock this door. Please check the Iris app to ensure all doors have successfully locked.
+	A door is unlocked and the security alarm is armed at {{_place_name}}.  Arcus is attempting to automatically lock this door. Please check the Arcus app to ensure all doors have successfully locked.
 	{{/partial}}
 
 	{{#partial "extra" }}{{/partial}}


### PR DESCRIPTION
This addresses the remaining part of #25, where the push notifications still mention "Iris"