### PR TITLE
Allow Twitter handle to be set via environment variable

### DIFF
--- a/platform/arcus-containers/notification-services/src/main/java/com/iris/notification/message/TemplateMessageRenderer.java
+++ b/platform/arcus-containers/notification-services/src/main/java/com/iris/notification/message/TemplateMessageRenderer.java
@@ -45,11 +45,12 @@ public class TemplateMessageRenderer implements NotificationMessageRenderer {
    public static final String CUSTOM_MESSAGE_KEY="customMessage";
    private final static String CUSTOM_TEMPLATE="custom.notification";
    private final static String RESOURCE_SERVER_URL_KEY="static.resource.server.url";
+   private final static String TWITTER_UNAME_KEY = "twitter.uname";
    private final static String REDIRECT_BASE_URL_KEY="redirect.base.url";
-	private static final String WEBHOME_BASE_URL_KEY = "webhome.base.url";
+   private static final String WEBHOME_BASE_URL_KEY = "webhome.base.url";
    
    @Inject @Named(RESOURCE_SERVER_URL_KEY) String staticResourceServerUrl;      
-   @Inject @Named(TWITTER_UNAME_CONTEXT_KEY) String atTwitter;
+   @Inject @Named(TWITTER_UNAME_KEY) String atTwitter;
    @Inject @Named(REDIRECT_BASE_URL_KEY) String redirectBaseUrl;
    @Inject @Named(WEBHOME_BASE_URL_KEY) String webHomeBaseUrl;
    

--- a/platform/arcus-containers/notification-services/src/test/java/com/iris/notification/message/TestMessages.java
+++ b/platform/arcus-containers/notification-services/src/test/java/com/iris/notification/message/TestMessages.java
@@ -53,7 +53,7 @@ public class TestMessages extends IrisMockTestCase {
 	public static final String MSG_KEY_ENUM = "enum";
 	
 	static {
-		System.setProperty("_atTwitter", "tweet");
+		System.setProperty("twitter.uname", "tweet");
 		System.setProperty("static.resource.server.url", "http://fakeurl");
 	}
 	


### PR DESCRIPTION
Allow the twitter handle to be configured as an environment variable, instead of needing to be hard coded in the properties file (underscore and mixed case can't be set via ENV)