### PR TITLE
Upgrade cassandra to 3.11.4

### DIFF
--- a/khakis/eyeris-cassandra/Dockerfile
+++ b/khakis/eyeris-cassandra/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Environment variables for configuration
-ENV CASSANDRA_VERSION 2.2.9
+ENV CASSANDRA_VERSION 3.11.4
 
 # Download and install the required version of Apache Cassandra. 
 RUN \

--- a/khakis/eyeris-cassandra/cassandra-cmd
+++ b/khakis/eyeris-cassandra/cassandra-cmd
@@ -149,10 +149,10 @@ cassandra_setup() {
 cassandra_start() {
     if [ -z "${EYERIS_CASSANDRA_INIT}" ] && [ -z "${CASSANDRA_SINGLE_NODE}" ]; then
         echo "Starting Apache Cassandra Server..."
-        exec "${CASSANDRA_HOME}/bin/cassandra" "-f"
+        exec "${CASSANDRA_HOME}/bin/cassandra" "-fR"
      else
         echo "Initializing fresh Apache Cassandra Server..."
-        exec "${CASSANDRA_HOME}/bin/cassandra" "-f" "-Dcassandra.auto_bootstrap=false"
+        exec "${CASSANDRA_HOME}/bin/cassandra" "-fR" "-Dcassandra.auto_bootstrap=false"
     fi
 }
 

--- a/platform/arcus-modelmanager/src/dist/video-resources/changelogs/changelog-master.xml
+++ b/platform/arcus-modelmanager/src/dist/video-resources/changelogs/changelog-master.xml
@@ -9,4 +9,5 @@
   <cl:import file="video-2.13.0.xml"/>
   <cl:import file="video-2018.7.0.xml"/>
   <cl:import file="video-2018.9.0.xml"/>
+  <cl:import file="video-2019.6.0.xml"/>
 </cl:changelog>

--- a/platform/arcus-modelmanager/src/dist/video-resources/changelogs/video-2019.6.0.xml
+++ b/platform/arcus-modelmanager/src/dist/video-resources/changelogs/video-2019.6.0.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cl:changelog
+   version="2019.6.0"
+   xmlns:cl="http://www.iris.com/schema/changelog/1.0.0">
+
+   <cl:changeset identifier="changeRecordingCompaction" author="andrewx192">
+      <cl:description>Change recording_v2 compaction strategy</cl:description>
+      <cl:tracking></cl:tracking>
+      <cl:cql>
+         <cl:update>ALTER table recording_v2 WITH compaction =
+            {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy',
+            'compaction_window_size': '1', 'compaction_window_unit': 'DAYS'};</cl:update>
+         <cl:rollback>ALTER table recording_v2 WITH compaction =
+            {'class': 'com.jeffjirsa.cassandra.db.compaction.TimeWindowCompactionStrategy',
+            'compaction_window_size': '1', 'compaction_window_unit': 'DAYS'};</cl:rollback>
+      </cl:cql>
+   </cl:changeset>
+   <cl:changeset identifier="changeRecordingMetadataCompaction" author="andrewx192">
+      <cl:description>Change recording_metadata_v2 compaction strategy</cl:description>
+      <cl:tracking></cl:tracking>
+      <cl:cql>
+         <cl:update>ALTER table recording_metadata_v2 WITH compaction =
+            {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy',
+            'compaction_window_size': '1', 'compaction_window_unit': 'DAYS'};</cl:update>
+         <cl:rollback>ALTER table recording_metadata_v2 WITH compaction =
+            {'class': 'com.jeffjirsa.cassandra.db.compaction.TimeWindowCompactionStrategy',
+            'compaction_window_size': '1', 'compaction_window_unit': 'DAYS'};</cl:rollback>
+      </cl:cql>
+   </cl:changeset>
+   <cl:changeset identifier="changePlaceRecordingCompaction" author="andrewx192">
+      <cl:description>Change compaction strategy</cl:description>
+      <cl:tracking></cl:tracking>
+      <cl:cql>
+         <cl:update>ALTER table place_recording_index_v2 WITH compaction =
+            {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy',
+            'compaction_window_size': '1', 'compaction_window_unit': 'DAYS'};</cl:update>
+         <cl:rollback>ALTER table place_recording_index_v2 WITH compaction =
+            {'class': 'com.jeffjirsa.cassandra.db.compaction.TimeWindowCompactionStrategy',
+            'compaction_window_size': '1', 'compaction_window_unit': 'DAYS'};</cl:rollback>
+      </cl:cql>
+   </cl:changeset>
+</cl:changelog>


### PR DESCRIPTION
This pull request updates cassandra from 2.2.9 to 3.11.4, bringing in years of improvements. Thus far, I've not had trouble with simply publishing the container and running an sstable upgrade. The existing TimeWindowCompactionStrategy has been integrated into cassandra, so the standalone jar file is no longer needed, however existing installations will require it until the upgrade is complete.

I'll follow up with a future revision to remove TimeWindowCompactionStrategy, so that upgrades (if needed) can be done in a staged process, rather than all at once.