### PR TITLE
Add support for changing listener in cassandra, kafka, and zookeeper

### DIFF
--- a/khakis/eyeris-cassandra/cassandra-cmd
+++ b/khakis/eyeris-cassandra/cassandra-cmd
@@ -43,8 +43,12 @@ cassandra_init() {
    local CID=$(cat /data/clusterid 2>/dev/null)
    [ -z "${CID}" ] && CID="eyeris_prod"
 
+   if [[ -z "${CASSANDRA_HOST}" ]]; then
+        CASSANDRA_HOST="cassandra.eyeris" # for local docker
+   fi
+
    local SEEDS="${CASSANDRA_SEEDS}"
-   [ -z "${SEEDS}" ] && SEEDS=$(dig +nocomments +noauthority +noadditional +nostats cassandra.eyeris |grep -v '^;' |grep . |awk '{print $5}')
+   [ -z "${SEEDS}" ] && SEEDS=$(dig +nocomments +noauthority +noadditional +nostats $CASSANDRA_HOST |grep -v '^;' |grep . |awk '{print $5}')
    [ -z "${SEEDS}" ] && SEEDS="127.0.0.1"
 
     SDS=""
@@ -80,11 +84,20 @@ cassandra_init() {
     # Set some configuration parameters
     sed -i "s/^\s*cluster_name\s*:.*$/cluster_name: '${CID}'/" $CASSANDRA_HOME/conf/cassandra.yaml
 
-    sed -i "s/^\s*listen_address\s*:.*$/#listen_address: localhost/" $CASSANDRA_HOME/conf/cassandra.yaml
-    sed -i "s/^\s*#\s*listen_interface\s*:.*$/listen_interface: eth0/" $CASSANDRA_HOME/conf/cassandra.yaml
+    if [[ -n "${CASSANDRA_LISTEN_ADDRESS}" ]]; then
+        sed -i "s/^\s*listen_address\s*:.*$/listen_address: ${CASSANDRA_LISTEN_ADDRESS}/" $CASSANDRA_HOME/conf/cassandra.yaml
+	sed -i "s/^\s*rpc_address\s*:.*$/rpc_address: ${CASSANDRA_LISTEN_ADDRESS}/" $CASSANDRA_HOME/conf/cassandra.yaml
 
-    sed -i "s/^\s*rpc_address\s*:.*$/#rpc_address: localhost/" $CASSANDRA_HOME/conf/cassandra.yaml
-    sed -i "s/^\s*#\s*rpc_interface\s*:.*$/rpc_interface: eth0/" $CASSANDRA_HOME/conf/cassandra.yaml
+    else
+
+        # old behavior
+        sed -i "s/^\s*listen_address\s*:.*$/#listen_address: localhost/" $CASSANDRA_HOME/conf/cassandra.yaml
+        sed -i "s/^\s*#\s*listen_interface\s*:.*$/listen_interface: eth0/" $CASSANDRA_HOME/conf/cassandra.yaml
+
+        sed -i "s/^\s*rpc_address\s*:.*$/#rpc_address: localhost/" $CASSANDRA_HOME/conf/cassandra.yaml
+        sed -i "s/^\s*#\s*rpc_interface\s*:.*$/rpc_interface: eth0/" $CASSANDRA_HOME/conf/cassandra.yaml
+
+    fi
 
     sed -i "s/^\s*rpc_server_type\s*:.*$/rpc_server_type: hsha/" $CASSANDRA_HOME/conf/cassandra.yaml
     sed -i "s/^\s*#\s*rpc_min_threads\s*:.*$/rpc_min_threads: 16/" $CASSANDRA_HOME/conf/cassandra.yaml

--- a/khakis/eyeris-kafka/kafka-cmd
+++ b/khakis/eyeris-kafka/kafka-cmd
@@ -58,7 +58,12 @@ kafka_init() {
     if [[ -n ${ADVERTISED_HSTN} ]] ; then
         echo "advertised.listeners=PLAINTEXT://$ADVERTISED_HSTN:9092" >> $KAFKA_HOME/config/server.properties
     fi
-    
+
+    if [[ -n ${LISTENERS} ]] ; then
+	# e.g. PLAINTEXT://localhost:9092 for Istio
+        echo "listeners=${LISTENERS}" >> $KAFKA_HOME/config/server.properties
+    fi
+
     if [[ -n ${KAFKA_PROTOCOL_VERSION} ]] ; then
         echo "inter.broker.protocol.version=${KAFKA_PROTOCOL_VERSION}" >> $KAFKA_HOME/config/server.properties
     else 

--- a/khakis/eyeris-zookeeper/zookeeper-cmd
+++ b/khakis/eyeris-zookeeper/zookeeper-cmd
@@ -57,6 +57,10 @@ autopurge.snapRetainCount=3
 autopurge.purgeInterval=1
 EOF
 
+    if [[ -n ${CLIENT_PORT_ADDRESS} ]] ; then
+        echo "clientPortAddress=${CLIENT_PORT_ADDRESS}" >> "${ZOOKEEPER_HOME}/conf/zoo.cfg"
+    fi
+
     cat >"${ZOOKEEPER_HOME}/conf/java.env" <<EOF
 export JVMFLAGS="-Xmx64m -Xms64m"
 EOF


### PR DESCRIPTION
This revision allows the listener to be configured for cassandra, kafka, and zookeeper, as well as allowing the host for seeds in cassandra to be set to something other than cassandra.eyeris

This is needed to get Arcus working within kubernetes, where services sit behind a servicemsh that binds to the pod ip address, instead of the service directly.