### PR TITLE
Update kafka to 2.2.0

### DIFF
--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -10,7 +10,7 @@ RUN \
 
 # Environment variables for configuration
 ENV KAFKA_SCALA_VERSION 2.11
-ENV KAFKA_VERSION 0.10.0.1
+ENV KAFKA_VERSION 2.2.0
 
 # Download and install the required version of Apache Kafka. 
 RUN \

--- a/khakis/eyeris-kafka/kafka-cmd
+++ b/khakis/eyeris-kafka/kafka-cmd
@@ -55,6 +55,8 @@ kafka_init() {
     sed -i "s/^\s*num.partitions\s*=.*$/num.partitions=32/" $KAFKA_HOME/config/server.properties
     sed -i "s/^\s*num.recovery.threads.per.data.dir\s*=.*$/num.recovery.threads.per.data=4/" $KAFKA_HOME/config/server.properties
 
+    echo "" >> $KAFKA_HOME/config/server.properties # newer versions don't have a newline at the end.
+
     if [[ -n ${ADVERTISED_HSTN} ]] ; then
         echo "advertised.listeners=PLAINTEXT://$ADVERTISED_HSTN:9092" >> $KAFKA_HOME/config/server.properties
     fi


### PR DESCRIPTION
Arcus currently uses a really old version of Kafka. This pull request bumps it to 2.2.0, which I've been using in production for the last month.