### PR TITLE
Bump kafka to 2.3.0

### DIFF
--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -10,7 +10,7 @@ RUN \
 
 # Environment variables for configuration
 ENV KAFKA_SCALA_VERSION 2.11
-ENV KAFKA_VERSION 2.2.0
+ENV KAFKA_VERSION 2.3.0
 
 # Download and install the required version of Apache Kafka. 
 RUN \


### PR DESCRIPTION
Upgrades kafka in eyeris-kafka to the latest version, see https://www.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html