### PR TITLE
Allow cassandra commitlog size to be configured

### DIFF
--- a/khakis/eyeris-cassandra/cassandra-cmd
+++ b/khakis/eyeris-cassandra/cassandra-cmd
@@ -115,6 +115,10 @@ cassandra_init() {
         CASSANDRA_ENDPOINT_SNITCH="SimpleSnitch"
     fi
 
+    if [[ -n "${CASSANDRA_COMMITLOG_TOTAL_SPACE_IN_MB}" ]]; then
+	sed -i "s/^# commitlog_total_space_in_mb:\s.*$/commitlog_total_space_in_mb: ${CASSANDRA_COMMITLOG_TOTAL_SPACE_IN_MB}/" $CASSANDRA_HOME/conf/cassandra.yaml
+    fi
+
     sed -i "s/^\s*endpoint_snitch: SimpleSnitch$/endpoint_snitch: ${CASSANDRA_ENDPOINT_SNITCH}/" $CASSANDRA_HOME/conf/cassandra.yaml
 
     if [[ -n "${CASSANDRA_CONCURRENT_COMPACTORS}" ]]; then


### PR DESCRIPTION
Newer versions of cassandra use a considerably larger commitlog (Default: 32MB for 32-bit JVMs, 8192MB for 64-bit JVMs). When using Kairosdb (which will be introduced in a future pull request to add a metrics dashboard, grafana), this can become a significant issue on systems with limited disk space.