### PR TITLE
Add travisci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: java
-
+jdk:
+- openjdk8


### PR DESCRIPTION
Add a travisci configuration file that targets java8 - currently this simple configuration file runs the tests target for all included projects. In order for this to do anything useful, a member of the arcus-smart-home organization will need to login to travis ci and set it up.