### PR TITLE
Allow keyspace to be configured when provisioning

### DIFF
--- a/khakis/eyeris-cassandra/cassandra-provision
+++ b/khakis/eyeris-cassandra/cassandra-provision
@@ -9,7 +9,7 @@ if [ -e /etc/install/.eyeris-cassandra ]; then
    fi
 fi
 
-KEYSPACE=dev
+KEYSPACE=${CASSANDRA_KEYSPACE:-dev}
 SUPPORT_KEYSPACE=support
 VIDEO_KEYSPACE=video
 HISTORY_KEYSPACE=history


### PR DESCRIPTION
This pull request allows the administrator to provision cassandra into a keyspace other than develop. Presumably the existing script was more intended for local development and production clusters were rarely (if ever more than 1-2x) provisioned, so this was not customizable.