### PR TITLE
Use eyeris/java instead of deprecated dockerfile/java

### DIFF
--- a/tools/arcus-captools/build.gradle
+++ b/tools/arcus-captools/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     compile project(':common:arcus-model')
 }
 
+docker {
+   baseImage "eyeris/java"
+}
 
 tasks.addRule("Pattern: <CodeGenerationType>Code") {
     String taskName ->


### PR DESCRIPTION
dockerfile/java is gone now, so we need to switch to an alternative. fortunately eyeris/java is available and should be suitable for this.