### PR TITLE
Run platform containers as "arcus" user instead of root

### DIFF
--- a/khakis/eyeris-cassandra/Dockerfile
+++ b/khakis/eyeris-cassandra/Dockerfile
@@ -1,6 +1,8 @@
 # Use the standard eyeris java image
 FROM eyeris/java
 
+USER root
+
 # Initial system configuration
 #  python is required to run cqlsh
 #  unzip is required to unzip the modelmanager jar

--- a/khakis/eyeris-java/Dockerfile
+++ b/khakis/eyeris-java/Dockerfile
@@ -22,5 +22,9 @@ WORKDIR /data
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
+RUN \
+    groupadd -g 999 arcus && \
+    useradd -r -u 999 -g arcus arcus
+
 # Define default command.
 CMD ["bash"]

--- a/khakis/eyeris-java/Dockerfile
+++ b/khakis/eyeris-java/Dockerfile
@@ -26,5 +26,7 @@ RUN \
     groupadd -g 999 arcus && \
     useradd -r -u 999 -g arcus arcus
 
+USER arcus
+
 # Define default command.
 CMD ["bash"]

--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -1,6 +1,8 @@
 # Use the standard eyeris java image
 FROM eyeris/java
 
+USER root
+
 # Initial system configuration
 RUN \
     apt-get update && \

--- a/khakis/eyeris-zookeeper/Dockerfile
+++ b/khakis/eyeris-zookeeper/Dockerfile
@@ -1,6 +1,8 @@
 # Use the standard eyeris java image
 FROM eyeris/java
 
+USER root
+
 # Initial system configuration
 RUN \
     apt-get update && \


### PR DESCRIPTION
This pull request is the first in a series to reduce the amount of permissions that processes have within Arcus. The system (khakis) containers are more difficult to work out, since they persist but the platform containers are stateless and thus are relatively easy to convert to use least-privilege.

Note that the docker gradle plugin that's being used doesn't support changing the Docker user, so we have to change the user for eyeris/java and overwrite it back to root for the khakis containers (for now)