### PR TITLE
Allow global and metrics topic retention to be configured 

### DIFF
--- a/khakis/eyeris-kafka/kafka-cmd
+++ b/khakis/eyeris-kafka/kafka-cmd
@@ -82,6 +82,14 @@ kafka_init() {
         echo "log.segment.bytes=${KAFKA_LOG_SEGMENT_BYTES}" >> $KAFKA_HOME/config/server.properties
     fi
 
+    if [[ -n ${KAFKA_LOG_RETENTION_BYTES} ]] ; then
+        echo "log.retention.bytes=${KAFKA_LOG_RETENTION_BYTES}" >> $KAFKA_HOME/config/server.properties
+    fi
+
+    if [[ -n ${KAFKA_LOG_RETENTION_MS} ]] ; then
+        echo "log.retention.ms=${KAFKA_LOG_RETENTION_MS}" >> $KAFKA_HOME/config/server.properties
+    fi
+
     if [[ -n ${KAFKA_AUTO_CREATE_TOPICS_ENABLE} ]] ; then
         echo "auto.create.topics.enable=${KAFKA_AUTO_CREATE_TOPICS_ENABLE}" >> $KAFKA_HOME/config/server.properties
     fi 

--- a/khakis/eyeris-kafka/kafka-cmd
+++ b/khakis/eyeris-kafka/kafka-cmd
@@ -78,6 +78,9 @@ kafka_init() {
         echo "log.message.format.version=0.10.0.1" >> $KAFKA_HOME/config/server.properties
     fi 
 
+    if [[ -n ${KAFKA_LOG_SEGMENT_BYTES} ]] ; then
+        echo "log.segment.bytes=${KAFKA_LOG_SEGMENT_BYTES}" >> $KAFKA_HOME/config/server.properties
+    fi
 
     if [[ -n ${KAFKA_AUTO_CREATE_TOPICS_ENABLE} ]] ; then
         echo "auto.create.topics.enable=${KAFKA_AUTO_CREATE_TOPICS_ENABLE}" >> $KAFKA_HOME/config/server.properties

--- a/khakis/eyeris-kafka/kafka-operations-provision
+++ b/khakis/eyeris-kafka/kafka-operations-provision
@@ -48,6 +48,17 @@ echo "Creating Kafka Provisions Topics..."
 "${KAFKA_HOME}/bin/kafka-topics.sh" --zookeeper "${ZOOKEEPEROPS}" --create --partitions 128 --replication-factor ${KAFKAOPS_REPLICATION} --topic "irisLog" & PID0=$!
 "${KAFKA_HOME}/bin/kafka-topics.sh" --zookeeper "${ZOOKEEPEROPS}" --create --partitions 128 --replication-factor ${KAFKAOPS_REPLICATION} --topic "metrics" & PID1=$!
 
+if [[ -n "$KAFAOPS_METRICS_LOG_RETENTION_MS" ]]; then
+   echo "Altering metrics retention.ms"
+   "${KAFKA_HOME}/bin/kafka-configs.sh" --zookeeper "${ZOOKEEPEROPS}" --alter --entity-type topics --entity-name metrics --add-config retention.ms=${KAFAOPS_METRICS_LOG_RETENTION_MS}
+fi
+
+if [[ -n "$KAFAOPS_METRICS_LOG_RETENTION_BYTES" ]]; then
+   echo "Altering metrics retention.ms"
+   "${KAFKA_HOME}/bin/kafka-configs.sh" --zookeeper "${ZOOKEEPEROPS}" --alter --entity-type topics --entity-name metrics --add-config retention.bytes=${KAFAOPS_METRICS_LOG_RETENTION_BYTES}
+fi
+
+
 wait $PID0; RESULT=$(($RESULT | $?))
 wait $PID1; RESULT=$(($RESULT | $?))
 


### PR DESCRIPTION
This pull request introduces the ability to configure global retention as well as specific retention for the "metrics" topic (one of the top consumers of disk space) during provisioning. Because kafka does not persist topic configuration, users may find it helpful to use a combination of both options to better manage disk resources.