### PR TITLE
Don't run kafka as root

### DIFF
--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -19,7 +19,12 @@ RUN \
     wget https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz -O /tmp/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
     tar xfz /tmp/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && \
     ln -s /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka && \
-    rm /tmp/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz
+    rm /tmp/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
+    chown -R arcus:arcus /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}
+
+RUN \
+    /bin/bash -c '127.0.0.1	kafka.eyeris' && \
+    /bin/bash -c '127.0.0.1     kafkaops.eyeris'
 
 # Add Apache Kafka control script and debug utilities
 ADD kafka-cmd /usr/bin/kafka-cmd 
@@ -36,6 +41,8 @@ ENV KAFKA_HOME /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}
 
 # Expose the Apache Kafka port to the outside
 EXPOSE 9092
+
+USER arcus
 
 # Set the entry point as "kafka-cmd init"
 ENTRYPOINT ["/usr/bin/kafka-cmd", "entry"]

--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -42,7 +42,7 @@ ENV KAFKA_HOME /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}
 # Expose the Apache Kafka port to the outside
 EXPOSE 9092
 
-USER arcus
+USER kafka
 
 # Set the entry point as "kafka-cmd init"
 ENTRYPOINT ["/usr/bin/kafka-cmd", "entry"]

--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -6,7 +6,7 @@ USER root
 # Initial system configuration
 RUN \
     apt-get update && \
-    apt-get install -y wget && \
+    apt-get install -y wget runit && \
     useradd -M -U -r -s /bin/false kafka && \
     rm -rf /var/lib/apt/lists/*
 
@@ -23,8 +23,8 @@ RUN \
     chown -R arcus:arcus /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}
 
 RUN \
-    /bin/bash -c '127.0.0.1	kafka.eyeris' && \
-    /bin/bash -c '127.0.0.1     kafkaops.eyeris'
+    /bin/bash -c 'echo "127.0.0.1	kafka.eyeris" > /etc/hosts' && \
+    /bin/bash -c 'echo "127.0.0.1     kafkaops.eyeris" > /etc/hosts'
 
 # Add Apache Kafka control script and debug utilities
 ADD kafka-cmd /usr/bin/kafka-cmd 

--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -6,7 +6,7 @@ USER root
 # Initial system configuration
 RUN \
     apt-get update && \
-    apt-get install -y wget runit && \
+    apt-get install -y wget && \
     useradd -M -U -r -s /bin/false kafka && \
     rm -rf /var/lib/apt/lists/*
 

--- a/khakis/eyeris-kafka/Dockerfile
+++ b/khakis/eyeris-kafka/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     tar xfz /tmp/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && \
     ln -s /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka && \
     rm /tmp/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
-    chown -R arcus:arcus /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}
+    chown -R kafka:kafka /opt/kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}
 
 RUN \
     /bin/bash -c 'echo "127.0.0.1	kafka.eyeris" > /etc/hosts' && \

--- a/khakis/eyeris-kafka/kafka-operations-provision
+++ b/khakis/eyeris-kafka/kafka-operations-provision
@@ -37,8 +37,6 @@ else
    echo "Kafka is online"
 fi
 
-echo "127.0.0.1	kafkaops.eyeris" >> /etc/hosts
-
 export KAFKA_HEAP_OPTS="-Xmx4m -Xms4m"
 export KAFKA_JVM_PERFORMANCE_OPTS="-client -Djava.awt.headless=true"
 

--- a/khakis/eyeris-kafka/kafka-provision
+++ b/khakis/eyeris-kafka/kafka-provision
@@ -37,8 +37,6 @@ else
    echo "Kafka is online"
 fi
 
-echo "127.0.0.1	kafka.eyeris" >> /etc/hosts
-
 export KAFKA_HEAP_OPTS="-Xmx4m -Xms4m"
 export KAFKA_JVM_PERFORMANCE_OPTS="-client -Djava.awt.headless=true"
 


### PR DESCRIPTION
Kafka does not need to run as root, and doing so makes it easier for an attacker who has code execution in Kafka to escape the container. This pull request configures kafka to run as the previously created "kafka" user (uid 998) instead of "root" or "arcus" (like other containers).

Also, since the provision scripts can't assume root, the container image now has the hosts file entry for `kafkaops.eyeris` configured in the image itself - in production a different hostname should be used, rather than trying to enumerate possible hosts via IP addresses.