### PR TITLE
Use stronger AEAD cipher suites 

### DIFF
--- a/agent/arcus-gateway/src/main/java/com/iris/agent/gateway/GatewayConnection.java
+++ b/agent/arcus-gateway/src/main/java/com/iris/agent/gateway/GatewayConnection.java
@@ -74,7 +74,8 @@ public class GatewayConnection {
    private static final Logger SECONDARY_LOG = LoggerFactory.getLogger(GatewayConnection.class.getName() + ".sec");
 
    private static final String[] ALLOWED_CIPHERS = new String[] {
-      "ECDHE-RSA-AES128-GCM-SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
       "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
    };
 

--- a/platform/arcus-containers/hub-bridge/src/dist/conf/hub-bridge.properties
+++ b/platform/arcus-containers/hub-bridge/src/dist/conf/hub-bridge.properties
@@ -6,7 +6,7 @@ partition.assignment=ALL
 kafka.offsets.transient=true
 
 tls.server=true
-tls.server.ciphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+tls.server.ciphers=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
 tls.server.protocols=TLSv1.2
 tls.server.keystore.filepath=keystore.jks
 tls.server.keystore.password=


### PR DESCRIPTION
When the hub communicates to the arcusplatform, it currently uses `TLS_DHE_RSA_WITH_AES_128_CBC_SHA256` which has known weaknesses. Curiously, the agent theoretically intended to support ECDHE-RSA-AES128-GCM-SHA256, but it appears the string entered was wrong (it should be `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`). This change configures the agent to use `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`, with an AES-128/SHA-256 variant and the old DHE CBC option as a fallback (for now). This results in the hub server getting an "A" grade from ssllabs instead of the "B" that it got before.

I've verified this change on my staging instance, and confirmed that removing `TLS_DHE_RSA_WITH_AES_128_CBC_SHA256` from the server's supported cipher list doesn't result in connectivity issues.

TLS 1.3 *may* be possible in Java 8, but is not a priority at the moment.