### PR TITLE
Bump zookeeper to 3.5.5

### DIFF
--- a/khakis/eyeris-zookeeper/Dockerfile
+++ b/khakis/eyeris-zookeeper/Dockerfile
@@ -11,12 +11,13 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Environment variables for configuration
-ENV ZOOKEEPER_VERSION 3.4.14
+ENV ZOOKEEPER_VERSION 3.5.5
 
 # Download and install the required version of Apache Zookeeper.
 RUN \
-    wget http://mirrors.ibiblio.org/apache/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz -O /tmp/zookeeper-${ZOOKEEPER_VERSION}.tar.gz && \
+    wget http://mirrors.ibiblio.org/apache/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz -O /tmp/zookeeper-${ZOOKEEPER_VERSION}.tar.gz && \
     tar xfz /tmp/zookeeper-${ZOOKEEPER_VERSION}.tar.gz -C /opt && \
+    mv /opt/apache-zookeeper-${ZOOKEEPER_VERSION}-bin /opt/zookeeper-${ZOOKEEPER_VERSION} && \
     ln -s /opt/zookeeper-${ZOOKEEPER_VERSION} /opt/zookeeper && \
     rm /tmp/zookeeper-${ZOOKEEPER_VERSION}.tar.gz
 

--- a/khakis/eyeris-zookeeper/zookeeper-cmd
+++ b/khakis/eyeris-zookeeper/zookeeper-cmd
@@ -38,6 +38,8 @@ zookeeper_init() {
 
     # Setup the data directory
     mkdir -p "${ZOOKEEPER_DATA_DIR}"
+    mkdir -p "${ZOOKEEPER_HOME}/logs"
+    chown -R "zookeeper:zookeeper" "${ZOOKEEPER_HOME}/logs"
     chown -R "zookeeper:zookeeper" "${ZOOKEEPER_DATA_DIR}"
     chmod "0700" "${ZOOKEEPER_DATA_DIR}"
 


### PR DESCRIPTION
Bump zookeeper to 3.5.5, the latest stable version. This requires a few additional changes because the name of the tarball has changed for binary downloads.