### PR TITLE
enable netty tls sni

### DIFF
--- a/common/arcus-model/platform-client/src/main/java/com/iris/client/impl/netty/HttpRequester.java
+++ b/common/arcus-model/platform-client/src/main/java/com/iris/client/impl/netty/HttpRequester.java
@@ -72,7 +72,11 @@ public class HttpRequester {
          int retryAttempts, 
          int retryDelay,
          int maxResponseSize
-   ) {
+   ) throws IllegalArgumentException {
+      if(uri == null) {
+         throw new IllegalArgumentException("Cannot pass a null URI to HttpRequester");
+      }
+
       this.uri = uri;
       this.trustManagerFactory = trustManagerFactory;
       this.lostHandler = lostHandler;
@@ -189,7 +193,7 @@ public class HttpRequester {
       Bootstrap bootstrap = new Bootstrap();
       bootstrap.group(group)
          .channel(NioSocketChannel.class)
-         .handler(new HttpRequestInitializer(sslCtx, uri));
+         .handler(new HttpRequestInitializer(sslCtx, uri, port));
       
       ChannelFuture future = bootstrap.connect(host, port);
       future.addListener(new SslChannelFutureListener() {
@@ -242,17 +246,19 @@ public class HttpRequester {
    private class HttpRequestInitializer extends ChannelInitializer<SocketChannel> {
       private final SslContext sslCtx;
       private final URI uri;
+      private final int port;
 
-       HttpRequestInitializer(SslContext sslCtx, URI u) {
+       HttpRequestInitializer(SslContext sslCtx, URI u, int port) {
          this.sslCtx = sslCtx;
          this.uri = u;
+         this.port = port;
       }
 
       @Override
       protected void initChannel(SocketChannel ch) throws Exception {
          ChannelPipeline pipeline = ch.pipeline();
          if (sslCtx != null) {
-            pipeline.addLast(sslCtx.newHandler(ch.alloc(), this.uri.getHost(), this.uri.getPort()));
+             pipeline.addLast(sslCtx.newHandler(ch.alloc(), this.uri.getHost(), this.port));
          }
          pipeline.addLast(new IdleStateHandler(IDLE_TIMEOUT_SECONDS, IDLE_TIMEOUT_SECONDS, IDLE_TIMEOUT_SECONDS));
          pipeline.addLast(new HttpIdleStateHandler());

--- a/common/arcus-model/platform-client/src/main/java/com/iris/client/impl/netty/HttpRequester.java
+++ b/common/arcus-model/platform-client/src/main/java/com/iris/client/impl/netty/HttpRequester.java
@@ -252,7 +252,7 @@ public class HttpRequester {
       protected void initChannel(SocketChannel ch) throws Exception {
          ChannelPipeline pipeline = ch.pipeline();
          if (sslCtx != null) {
-             pipeline.addLast(sslCtx.newHandler(ch.alloc(), this.uri.getHost(), 443));
+            pipeline.addLast(sslCtx.newHandler(ch.alloc(), this.uri.getHost(), this.uri.getPort()));
          }
          pipeline.addLast(new IdleStateHandler(IDLE_TIMEOUT_SECONDS, IDLE_TIMEOUT_SECONDS, IDLE_TIMEOUT_SECONDS));
          pipeline.addLast(new HttpIdleStateHandler());


### PR DESCRIPTION
This will allow clients to operate on servers that require tls-sni.
Tested using oculus.