### PR TITLE
Add fatjar (shadowjar) target for platform-client to support building in the app

### DIFF
--- a/common/arcus-model/platform-client/README.md
+++ b/common/arcus-model/platform-client/README.md
@@ -1,0 +1,16 @@
+platform-client is used by various programs (e.g. oculus and the android app) to connect to the platform.
+
+# Building
+
+
+## As a fatjar (for use in other projects)
+
+`./gradlew :common:arcus-model:platform-client:shadowJar`
+
+The resulting jar will be located in ./common/arcus-model/platform-client/build/libs/platform-client-all.jar
+
+## As part of the platform
+
+`./gradlew :common:arcus-model:platform-client:jar`
+
+The resulting jar will be located in ./common/arcus-model/platform-client/build/libs/platform-client.jar

--- a/common/arcus-model/platform-client/build.gradle
+++ b/common/arcus-model/platform-client/build.gradle
@@ -86,10 +86,6 @@ task generateSource(type: JavaExec) {
 	}
 }
 
-shadowJar {
-  zip64 true
-}
-
 artifacts {
    archives shadowJar
 }

--- a/common/arcus-model/platform-client/build.gradle
+++ b/common/arcus-model/platform-client/build.gradle
@@ -21,6 +21,8 @@ ext.capabilityDir   = '../src/main/resources'
 ext.templateDir     = 'src/main/templates'
 ext.templateName    = 'client'
 
+apply plugin: 'com.github.johnrengelman.shadow'
+
 configurations {
 	generator {
 		description "Classpath for source generators"
@@ -82,6 +84,14 @@ task generateSource(type: JavaExec) {
 		args '-t', templateName, '-i', capabilityDir, '-o', generatedSrcDir
 		main 'com.iris.capability.generator.java.Generator'
 	}
+}
+
+shadowJar {
+  zip64 true
+}
+
+artifacts {
+   archives shadowJar
 }
 
 compileJava.dependsOn generateSource


### PR DESCRIPTION
By default the platform-client that's built doesn't include dependencies, which doesn't match the behavior observed in the platform-client that's included in the iOS app. This fix is necessary to unblock development in https://github.com/arcus-smart-home/arcusandroid/issues/1