### PR TITLE
Rename zwave stubs to support old iris2 code

### DIFF
--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWLocalProcessingDefault.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWLocalProcessingDefault.java
@@ -24,7 +24,7 @@ import com.iris.protocol.zwave.Protocol;
 
 import rx.Observable;
 
-public class ZWLocalProcessingDefault implements ZWLocalProcessing {
+public class ZWaveLocalProcessingDefault implements ZWLocalProcessing {
    
    @Inject
    public ZWLocalProcessingDefault() {

--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveController.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveController.java
@@ -126,7 +126,7 @@ public class ZWaveController implements PortHandler, LifeCycleListener, SceneHan
     * @param router Hub message router.
     */
    @Inject
-   public ZWController(Router router) {
+   public ZWaveController(Router router) {
       this.router = router;      
       ZWEventDispatcher.INSTANCE.register(this);
       ZWSpy.INSTANCE.initialize();      

--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveController.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveController.java
@@ -100,8 +100,8 @@ import rx.subjects.ReplaySubject;
  * 
  * @author Erik Larson
  */
-public class ZWController implements PortHandler, LifeCycleListener, SceneHandler<Port>, ZWEventListener {
-   private static final Logger logger = LoggerFactory.getLogger(ZWController.class);
+public class ZWaveController implements PortHandler, LifeCycleListener, SceneHandler<Port>, ZWEventListener {
+   private static final Logger logger = LoggerFactory.getLogger(ZWaveController.class);
    
    public static final HubBridgeAddress ADDRESS = HubAddressUtils.bridge("zwave", "ZWAV");
    private static final int ADD_REMOVE_DEVICE_TTL = (int)TimeUnit.MILLISECONDS.convert(30, TimeUnit.MINUTES);

--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessing.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessing.java
@@ -18,33 +18,14 @@ package com.iris.agent.zw;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import com.google.inject.Inject;
 import com.iris.messages.address.Address;
 import com.iris.protocol.zwave.Protocol;
 
 import rx.Observable;
 
-public class ZWLocalProcessingNoop implements ZWLocalProcessing {
-   
-   @Inject
-   public ZWLocalProcessingNoop() {
-   }
-
-   @Override
-   public boolean isOffline(Address addr) {
-      return false;
-   }
-
-   @Override
-   public void setOfflineTimeout(Address addr, long offlineTimeout) {
-   }
-
-   @Override
-   public Observable<?> send(Address addr, Protocol.Message msg) {
-      return Observable.empty();
-   }
-
-   @Override
-   public void addScheduledPoll(Address addr, long period, TimeUnit unit, Collection<byte[]> payloads) {
-   }
+public interface ZWaveLocalProcessing {
+   boolean isOffline(Address addr);
+      void setOfflineTimeout(Address addr, long offlineTimeout);
+      Observable<?> send(Address addr, Protocol.Message msg);
+      void addScheduledPoll(Address addr, long period, TimeUnit unit, Collection<byte[]> payloads);
 }

--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessingDefault.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessingDefault.java
@@ -24,10 +24,10 @@ import com.iris.protocol.zwave.Protocol;
 
 import rx.Observable;
 
-public class ZWaveLocalProcessingDefault implements ZWLocalProcessing {
+public class ZWaveLocalProcessingDefault implements ZWaveLocalProcessing {
    
    @Inject
-   public ZWLocalProcessingDefault() {
+   public ZWaveLocalProcessingDefault() {
    }
 
    @Override

--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessingNoop.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessingNoop.java
@@ -24,10 +24,10 @@ import com.iris.protocol.zwave.Protocol;
 
 import rx.Observable;
 
-public class ZWaveLocalProcessingNoop implements ZWLocalProcessing {
+public class ZWaveLocalProcessingNoop implements ZWaveLocalProcessing {
    
    @Inject
-   public ZWLocalProcessingNoop() {
+   public ZWaveLocalProcessingNoop() {
    }
 
    @Override

--- a/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessingNoop.java
+++ b/agent/arcus-zw-controller/src/main/java/com/iris/agent/zw/ZWaveLocalProcessingNoop.java
@@ -18,14 +18,33 @@ package com.iris.agent.zw;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import com.google.inject.Inject;
 import com.iris.messages.address.Address;
 import com.iris.protocol.zwave.Protocol;
 
 import rx.Observable;
 
-public interface ZWLocalProcessing {
-   boolean isOffline(Address addr);
-      void setOfflineTimeout(Address addr, long offlineTimeout);
-      Observable<?> send(Address addr, Protocol.Message msg);
-      void addScheduledPoll(Address addr, long period, TimeUnit unit, Collection<byte[]> payloads);
+public class ZWaveLocalProcessingNoop implements ZWLocalProcessing {
+   
+   @Inject
+   public ZWLocalProcessingNoop() {
+   }
+
+   @Override
+   public boolean isOffline(Address addr) {
+      return false;
+   }
+
+   @Override
+   public void setOfflineTimeout(Address addr, long offlineTimeout) {
+   }
+
+   @Override
+   public Observable<?> send(Address addr, Protocol.Message msg) {
+      return Observable.empty();
+   }
+
+   @Override
+   public void addScheduledPoll(Address addr, long period, TimeUnit unit, Collection<byte[]> payloads) {
+   }
 }


### PR DESCRIPTION
The old ZWave code used names like ZWaveController instead of ZWController. While the code is being rewritten (e.g. an interface to existing open source ZWave libraries is created), backwards compatibility with the old code on the hub is ideal, to allow for incremental updates, where the user only updates arcus-hub-controller but does not touch iris2-zwave-controller (for now).

The new Zigbee and Zwave implementation should follow the same interface that's demonstrated in the code, by looking at the commented out calls to ZWaveController and ZigbeeController.

Perhaps the other files should be renamed to ZWave* instead of ZW, but going to leave it for now to get a minimal change in. 