### PR TITLE
Use zwave stubs

### DIFF
--- a/agent/arcus-agent/src/main/java/com/iris/agent/IrisAgent.java
+++ b/agent/arcus-agent/src/main/java/com/iris/agent/IrisAgent.java
@@ -62,7 +62,7 @@ public final class IrisAgent implements Callable<Integer> {
       }
 
       BootUtils.initialize(new File(args[0]), configs);
-      log.info("iris agent boostrap complete");
+      log.info("iris agent bootstrap complete");
    }
 
    @Override

--- a/agent/arcus-hal/hub-v2/src/main/java/com/iris/agent/hal/IrisHalImpl.java
+++ b/agent/arcus-hal/hub-v2/src/main/java/com/iris/agent/hal/IrisHalImpl.java
@@ -42,6 +42,10 @@ import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import com.iris.agent.zw.ZWaveController;
+import com.iris.agent.zw.ZWaveLocalProcessing;
+import com.iris.agent.zw.ZWaveLocalProcessingDefault;
+import com.iris.agent.zw.ZWaveLocalProcessingNoop;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -790,7 +794,7 @@ public final class IrisHalImpl extends AbstractIrisHalCommon {
       protected void configure() {
          String disable = System.getenv("ZWAVE_DISABLE");
          if (disable != null) {
-            // bind(ZWaveLocalProcessing.class).to(ZWaveLocalProcessingNoop.class).asEagerSingleton();
+             bind(ZWaveLocalProcessing.class).to(ZWaveLocalProcessingNoop.class).asEagerSingleton();
             return;
          }
 
@@ -801,11 +805,9 @@ public final class IrisHalImpl extends AbstractIrisHalCommon {
             bind(String.class).annotatedWith(Names.named("iris.zwave.port")).toInstance(port);
          }
 
-         /*
-         bind(ZWaveDriverFactory.class).in(Singleton.class);
+//         bind(ZWaveDriverFactory.class).in(Singleton.class);
          bind(ZWaveController.class).in(Singleton.class);
          bind(ZWaveLocalProcessing.class).to(ZWaveLocalProcessingDefault.class).asEagerSingleton();
-         */
       }
    }
 

--- a/agent/arcus-hub-controller/src/main/java/com/iris/agent/controller/hub/HubController.java
+++ b/agent/arcus-hub-controller/src/main/java/com/iris/agent/controller/hub/HubController.java
@@ -41,7 +41,6 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import com.iris.agent.zigbee.ZigbeeController;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
@@ -73,8 +72,9 @@ import com.iris.agent.router.Port;
 import com.iris.agent.router.PortHandler;
 import com.iris.agent.router.Router;
 import com.iris.agent.storage.StorageService;
-import com.iris.agent.util.ThreadUtils;
 import com.iris.agent.watchdog.WatchdogService;
+import com.iris.agent.zigbee.ZigbeeController;
+import com.iris.agent.zw.ZWaveController;
 import com.iris.messages.MessageBody;
 import com.iris.messages.PlatformMessage;
 import com.iris.messages.address.Address;
@@ -558,11 +558,10 @@ public class HubController implements PortHandler, LifeCycleListener, BackupFini
          return null;
 
       default:
-         /*
          if (type.startsWith(HubZwaveCapability.NAMESPACE)) {
             port.send(ZWaveController.ADDRESS, message);
             return Port.HANDLED;
-         } else*/ if (type.startsWith(HubZigbeeCapability.NAMESPACE)
+         } else if (type.startsWith(HubZigbeeCapability.NAMESPACE)
         		 || type.startsWith(HubKitCapability.NAMESPACE)
         		 ) {
             port.send(ZigbeeController.ADDRESS, message);
@@ -830,7 +829,7 @@ public class HubController implements PortHandler, LifeCycleListener, BackupFini
       }, duration, TimeUnit.MILLISECONDS);
 
       updateLEDState();
-      // port.forward(ZWaveController.ADDRESS, message);
+       port.forward(ZWaveController.ADDRESS, message);
        port.forward(ZigbeeController.ADDRESS, message);
       // port.forward(SercommCameraController.ADDRESS, message);
       // port.forward(HueController.ADDRESS, message);
@@ -842,7 +841,7 @@ public class HubController implements PortHandler, LifeCycleListener, BackupFini
          doExitPairingMode();
       } else if (HubCapability.STATE_UNPAIRING.equals(oldState)) {
          if (force) {
-            // port.forward(ZWaveController.ADDRESS, message);
+             port.forward(ZWaveController.ADDRESS, message);
              port.forward(ZigbeeController.ADDRESS, message);
             // port.forward(SercommCameraController.ADDRESS, message);
          } else {
@@ -871,7 +870,7 @@ public class HubController implements PortHandler, LifeCycleListener, BackupFini
       }, duration, TimeUnit.MILLISECONDS);
 
       updateLEDState(IrisHal.isBatteryPowered(), LifeCycleService.getState(), FourgService.getState());
-      // port.forward(ZWaveController.ADDRESS, message);
+       port.forward(ZWaveController.ADDRESS, message);
        port.forward(ZigbeeController.ADDRESS, message);
       // port.forward(SercommCameraController.ADDRESS, message);
       // port.forward(HueController.ADDRESS, message);
@@ -902,7 +901,7 @@ public class HubController implements PortHandler, LifeCycleListener, BackupFini
          .build();
 
       PlatformMessage message = PlatformMessage.buildMessage(stopPairing, port.getSendPlatformAddress(), port.getSendPlatformAddress()).create();
-      // port.forward(ZWaveController.ADDRESS, message);
+       port.forward(ZWaveController.ADDRESS, message);
        port.forward(ZigbeeController.ADDRESS, message);
       // port.forward(SercommCameraController.ADDRESS, message);
       // port.forward(HueController.ADDRESS, message);
@@ -917,7 +916,7 @@ public class HubController implements PortHandler, LifeCycleListener, BackupFini
          .build();
 
       PlatformMessage message = PlatformMessage.buildMessage(stopUnpairing, port.getSendPlatformAddress(), port.getSendPlatformAddress()).create();
-      // port.forward(ZWaveController.ADDRESS, message);
+       port.forward(ZWaveController.ADDRESS, message);
        port.forward(ZigbeeController.ADDRESS, message);
       // port.forward(SercommCameraController.ADDRESS, message);
       // port.forward(HueController.ADDRESS, message);

--- a/agent/arcus-reflex-controller/build.gradle
+++ b/agent/arcus-reflex-controller/build.gradle
@@ -24,7 +24,8 @@ dependencies {
    compile project(':common:arcus-drivers:drivers-common')
 
    compile project(':agent:arcus-zigbee-controller')
+   compile project(':agent:arcus-zw-controller')
 
-	testCompile libraries.google_guava_testlib
+   testCompile libraries.google_guava_testlib
 }
 

--- a/agent/arcus-reflex-controller/src/main/java/com/iris/agent/reflex/ReflexController.java
+++ b/agent/arcus-reflex-controller/src/main/java/com/iris/agent/reflex/ReflexController.java
@@ -36,6 +36,9 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import com.iris.agent.zw.ZWaveLocalProcessing;
+import com.iris.protocol.zigbee.ZigbeeProtocol;
+import com.iris.protocol.zwave.ZWaveProtocol;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
@@ -113,11 +116,11 @@ public class ReflexController implements SnoopingPortHandler, LifeCycleListener 
    private final Router router;
 
    private final ZigbeeLocalProcessing zigbee;
+   private final ZWaveLocalProcessing zwave;
 
    /*
     * Disable protocols that use proprietary information.
     * 
-   private final ZWaveLocalProcessing zwave;
    private final SercommLocalProcessing sercomm;
    */
 
@@ -182,8 +185,8 @@ public class ReflexController implements SnoopingPortHandler, LifeCycleListener 
    public ReflexController(
       ReflexLocalProcessing localProcessing,
       ZigbeeLocalProcessing zigbee,
-      /*
       ZWaveLocalProcessing zwave,
+      /*
       SercommLocalProcessing sercomm,
       */
       Router router
@@ -192,8 +195,8 @@ public class ReflexController implements SnoopingPortHandler, LifeCycleListener 
       this.router = router;
 
       this.zigbee = zigbee;
-      /*
       this.zwave = zwave;
+      /*
       this.sercomm = sercomm;
       */
       this.localProcessing = localProcessing;
@@ -279,11 +282,11 @@ public class ReflexController implements SnoopingPortHandler, LifeCycleListener 
    public ZigbeeLocalProcessing zigbee() {
       return this.zigbee;
    }
-   /*
+
    public ZWaveLocalProcessing zwave() {
       return this.zwave;
    }
-   
+   /*
    public SercommLocalProcessing sercomm() {
       return this.sercomm;
    }
@@ -755,14 +758,14 @@ public class ReflexController implements SnoopingPortHandler, LifeCycleListener 
    private void sendOfflineTimeout(Address protocol, long offlineTimeout) {
       if (offlineTimeout > 0) {
          switch (((DeviceProtocolAddress)protocol).getProtocolName()) {
-         /*
+
          case ZigbeeProtocol.NAMESPACE:
             zigbee.setOfflineTimeout(protocol, offlineTimeout);
             break;
          case ZWaveProtocol.NAMESPACE:
             zwave.setOfflineTimeout(protocol, offlineTimeout);
             break;
-         */
+
          default:
             log.trace("cannot set offline timeout for unknown protocol: {}", protocol);
             break;


### PR DESCRIPTION
Actually make use of the ZWave stubs (note that they don't actually work in this project, but this means that if one copies the reflex-controller to the hub, they can continue to use the existing implementation for now)