### PR TITLE
Add a few generic ipcd devices

### DIFF
--- a/common/arcus-protocol/src/main/java/com/iris/protocol/ipcd/IpcdDeviceTypeRegistry.java
+++ b/common/arcus-protocol/src/main/java/com/iris/protocol/ipcd/IpcdDeviceTypeRegistry.java
@@ -35,6 +35,8 @@ public enum IpcdDeviceTypeRegistry {
    public static final String DEVICE_TYPE_SWANN_WIFI_BATTERY_CAMERA = "SwannWifiBatteryCamera";
    public static final String DEVICE_TYPE_GREATSTAR_INDOOR_WIFI_PLUG = "GreatStarIndoorPlug";
    public static final String DEVICE_TYPE_GREATSTAR_OUTDOOR_WIFI_PLUG = "GreatStarOutdoorPlug";
+   public static final String DEVICE_TYPE_GENERIC_SWITCH = "GenericSwitch";
+   public static final String DEVICE_TYPE_GENERIC_CONTACT_SENSOR = "GenericContactSensor";
    public static final String DEVICE_TYPE_OTHER = "Other";
 
    public static final IpcdDeviceType GENIE = createDeviceType("Genie", "Aladdin");
@@ -45,7 +47,8 @@ public enum IpcdDeviceTypeRegistry {
    public static final IpcdDeviceType SWANN_WIFI_BATTERY_CAMERA = createDeviceType("Swann", "SWWHD-INTCAM-US");
    public static final IpcdDeviceType GREATSTAR_INDOOR_PLUG = createDeviceType("GreatStar", "plug_indoor" );
    public static final IpcdDeviceType GREATSTAR_OUTDOOR_PLUG = createDeviceType("GreatStar", "plug_outdoor" );
-   
+   public static final IpcdDeviceType GENERIC_SWITCH = createDeviceType("Generic", "Switch");
+   public static final IpcdDeviceType GENERIC_CONTACT_SENSOR = createDeviceType("Generic", "ContactSensor");
 
    private static final Map<String, List<IpcdDeviceType>> V1_TYPES = ImmutableMap.<String, List<IpcdDeviceType>>builder()
       .put(DEVICE_TYPE_GENIE_GDO.toLowerCase(), ImmutableList.of(GENIE))
@@ -56,6 +59,7 @@ public enum IpcdDeviceTypeRegistry {
       .put(DEVICE_TYPE_SWANN_WIFI_BATTERY_CAMERA.toLowerCase(), ImmutableList.of(SWANN_WIFI_BATTERY_CAMERA))
       .put(DEVICE_TYPE_GREATSTAR_INDOOR_WIFI_PLUG.toLowerCase(), ImmutableList.of(GREATSTAR_INDOOR_PLUG))
       .put(DEVICE_TYPE_GREATSTAR_OUTDOOR_WIFI_PLUG.toLowerCase(), ImmutableList.of(GREATSTAR_OUTDOOR_PLUG))
+      .put(DEVICE_TYPE_GENERIC_CONTACT_SENSOR.toLowerCase(), ImmutableList.of(GENERIC_CONTACT_SENSOR))
       .build();
 
    private static final List<IpcdDeviceType> types;

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -94,7 +94,7 @@ onIpcdMessage.event {
          if (valueChange["parameter"] == ATTR_CONTACT) {
             def prevState = Contact.contact.get()
             Contact.contact( valueChange["value"] == 'opened' ? Contact.CONTACT_CLOSED : Contact.CONTACT_CLOSED )
-            if (Contact.state.get() != prevState) {
+            if (Contact.contact.get() != prevState) {
                Contact.contactchanged( new Date())
             }
          }

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -18,7 +18,7 @@ description    "Driver for emulated IPCD Contact Sensor"
 version        "1.0"
 protocol       "IPCD"
 deviceTypeHint "Contact"
-productId      "0c9a67"
+productId      "0c9a55"
 vendor         "Generic"
 model          "ContactSensor"
 

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -48,7 +48,7 @@ onAdded {
    DevicePower.sourcechanged        ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
 
    Contact.contact                  Contact.CONTACT_OPENED
-   Contact.statechanged             ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+   Contact.contactchanged           ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
 }
 
 onConnected {
@@ -93,9 +93,9 @@ onIpcdMessage.event {
       for (valueChange in valueChanges) {
          if (valueChange["parameter"] == ATTR_CONTACT) {
             def prevState = Contact.state.get()
-            Contact.state( valueChange["value"] == 'opened' ? Contact.OPENED : Contact.CLOSED )
+            Contact.state( valueChange["value"] == 'opened' ? Contact.CONTACT_CLOSED : Contact.CONTACT_CLOSED )
             if (Contact.state.get() != prevState) {
-               Contact.statechanged( new Date())
+               Contact.contactchanged( new Date())
             }
          }
       }

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+driver         "IPCDGenericContactSensor"
+description    "Driver for emulated IPCD Contact Sensor"
+version        "1.0"
+protocol       "IPCD"
+deviceTypeHint "Contact"
+productId      "0c9a67"
+vendor         "Generic"
+model          "ContactSensor"
+
+matcher        'IPCD:vendor' : 'Generic', 'IPCD:model' : 'ContactSensor'
+
+capabilities   DevicePower, Contact
+
+DevicePower.source                 DevicePower.SOURCE_LINE
+DevicePower.linecapable            true
+DevicePower.backupbatterycapable   false
+
+Contact {
+    Contact.contact  Contact.CONTACT_CLOSED
+    Contact.usehint  Contact.USEHINT_UNKNOWN
+    bind contactchanged to Contact.contact
+}
+
+///////////////// Constants ////////////////////////
+def final ATTR_CONTACT = "generic.contact"
+def final VALUE_CHANGES = "valueChanges"
+
+///////////////// Driver Lifecycle ////////////////
+
+onAdded {
+   log.debug "IPCD Generic Contact Sensor Device Added."
+
+   DevicePower.sourcechanged        ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+
+   Contact.contact                  Contact.CONTACT_OPENED
+   Contact.statechanged             ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+}
+
+onConnected {
+   log.debug "IPCD Generic Contact Switch Device Connected."
+   
+   Ipcd.Commands.getParameterValues("txnid", [ATTR_CONTACT])
+}
+
+onDisconnected {
+   log.debug "IPCD Generic Contact Switch Device Device Disconnected."
+}
+
+onRemoved {
+   Ipcd.Commands.factoryReset()
+   log.debug "IPCD Generic Contact Sensor Device Removed."
+}
+
+/////////////// Capability Attribute Closures ///////////////////
+
+setAttributes('cont') {
+   log.debug "IPCD Generic Contact Sensor driver received 'cont' set Attribute message " + message
+   def attributes = message.attributes
+   for (attribute in attributes) {
+		switch(attribute.key) {
+			case Contact.usehint:
+				Contact.usehint attribute.value
+				break;
+
+			default:
+				log.error "unrecognized attribute:{}", attribute
+		}
+   }
+}
+
+///////////////// Protocol Messages ///////////////////////////
+
+onIpcdMessage.event {
+   log.debug("Got event from IPCD Device " + message)
+   def eventMap = message.mapify()
+   if (eventMap.containsKey(VALUE_CHANGES)) {
+      def valueChanges = eventMap[VALUE_CHANGES]
+      for (valueChange in valueChanges) {
+         if (valueChange["parameter"] == ATTR_SWITCH) {
+            def prevState = Switch.state.get()
+            Switch.state( valueChange["value"] == 'on' ? Switch.STATE_ON : Switch.STATE_OFF )
+            if (Switch.state.get() != prevState) {
+               Switch.statechanged( new Date())
+            }
+         }
+      }
+   }
+}
+
+onIpcdMessage.response.getParameterValues("success") {
+   log.debug("Got Response from IPCD Device " + message)
+   def response = message.mapify()["response"]
+   log.debug("Response contents from IPCD Device " + response)
+   if (response.containsKey(ATTR_CONTACT)) {
+      Contact.contact( response[ATTR_CONTACT] == 'opened' ? Contact.CONTACT_OPENED : Contact.CONTACT_CLOSED )
+   }
+}
+
+

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -52,13 +52,13 @@ onAdded {
 }
 
 onConnected {
-   log.debug "IPCD Generic Contact Switch Device Connected."
+   log.debug "IPCD Generic Contact Sensor Device Connected."
    
    Ipcd.Commands.getParameterValues("txnid", [ATTR_CONTACT])
 }
 
 onDisconnected {
-   log.debug "IPCD Generic Contact Switch Device Device Disconnected."
+   log.debug "IPCD Generic Contact Sensor Device Device Disconnected."
 }
 
 onRemoved {
@@ -91,11 +91,11 @@ onIpcdMessage.event {
    if (eventMap.containsKey(VALUE_CHANGES)) {
       def valueChanges = eventMap[VALUE_CHANGES]
       for (valueChange in valueChanges) {
-         if (valueChange["parameter"] == ATTR_SWITCH) {
-            def prevState = Switch.state.get()
-            Switch.state( valueChange["value"] == 'on' ? Switch.STATE_ON : Switch.STATE_OFF )
-            if (Switch.state.get() != prevState) {
-               Switch.statechanged( new Date())
+         if (valueChange["parameter"] == ATTR_CONTACT) {
+            def prevState = Contact.state.get()
+            Contact.state( valueChange["value"] == 'opened' ? Contact.OPENED : Contact.CLOSED )
+            if (Contact.state.get() != prevState) {
+               Contact.statechanged( new Date())
             }
          }
       }

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -92,8 +92,8 @@ onIpcdMessage.event {
       def valueChanges = eventMap[VALUE_CHANGES]
       for (valueChange in valueChanges) {
          if (valueChange["parameter"] == ATTR_CONTACT) {
-            def prevState = Contact.state.get()
-            Contact.state( valueChange["value"] == 'opened' ? Contact.CONTACT_CLOSED : Contact.CONTACT_CLOSED )
+            def prevState = Contact.contact.get()
+            Contact.contact( valueChange["value"] == 'opened' ? Contact.CONTACT_CLOSED : Contact.CONTACT_CLOSED )
             if (Contact.state.get() != prevState) {
                Contact.contactchanged( new Date())
             }

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_ContactSensor_1_0.driver
@@ -93,7 +93,7 @@ onIpcdMessage.event {
       for (valueChange in valueChanges) {
          if (valueChange["parameter"] == ATTR_CONTACT) {
             def prevState = Contact.contact.get()
-            Contact.contact( valueChange["value"] == 'opened' ? Contact.CONTACT_CLOSED : Contact.CONTACT_CLOSED )
+            Contact.contact( valueChange["value"] == 'opened' ? Contact.CONTACT_OPENED : Contact.CONTACT_CLOSED )
             if (Contact.contact.get() != prevState) {
                Contact.contactchanged( new Date())
             }

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_Switch_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_Switch_1_0.driver
@@ -18,7 +18,7 @@ description    "Driver for emulated IPCD Switch"
 version        "1.0"
 protocol       "IPCD"
 deviceTypeHint "Switch"
-productId      "0c9a67"
+productId      "0c9a66"
 vendor         "Generic"
 model          "SwitchLinc"
 

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_Switch_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_Switch_1_0.driver
@@ -18,9 +18,9 @@ description    "Driver for emulated IPCD Switch"
 version        "1.0"
 protocol       "IPCD"
 deviceTypeHint "Switch"
-productId      "0c9a66"
+productId      "0c9a56"
 vendor         "Generic"
-model          "SwitchLinc"
+model          "Switch"
 
 matcher        'IPCD:vendor' : 'Generic', 'IPCD:model' : 'Switch'
 
@@ -47,24 +47,24 @@ onAdded {
 }
 
 onConnected {
-   log.debug "IPCD Generic Switch1 Device Connected."
+   log.debug "IPCD Generic Switch Device Connected."
    
    Ipcd.Commands.getParameterValues("txnid", [ATTR_SWITCH])
 }
 
 onDisconnected {
-   log.debug "IPCD Generic Switch1 Device Disconnected."
+   log.debug "IPCD Generic Switch Device Disconnected."
 }
 
 onRemoved {
    Ipcd.Commands.factoryReset()
-   log.debug "IPCD Generic Switch1 Device Removed."
+   log.debug "IPCD Generic Switch Device Removed."
 }
 
 /////////////// Capability Attribute Closures ///////////////////
 
 setAttributes('swit') {
-   log.debug "IPCD Generic Switch1 driver received 'swit' set Attribute message " + message
+   log.debug "IPCD Generic Switch driver received 'swit' set Attribute message " + message
    def attributes = message.attributes
    for (attribute in attributes) {
       switch(attribute.key) {
@@ -109,5 +109,3 @@ onIpcdMessage.response.getParameterValues("success") {
       Switch.state( response[ATTR_SWITCH] == 'on' ? Switch.STATE_ON : Switch.STATE_OFF )
    }
 }
-
-

--- a/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_Switch_1_0.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/IPCD_Generic_Switch_1_0.driver
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+driver         "IPCDGenericSwitch"
+description    "Driver for emulated IPCD Switch"
+version        "1.0"
+protocol       "IPCD"
+deviceTypeHint "Switch"
+productId      "0c9a67"
+vendor         "Generic"
+model          "SwitchLinc"
+
+matcher        'IPCD:vendor' : 'Generic', 'IPCD:model' : 'Switch'
+
+capabilities   DevicePower, Switch
+
+
+DevicePower.source                 DevicePower.SOURCE_LINE
+DevicePower.linecapable            true
+DevicePower.backupbatterycapable   false
+
+///////////////// Constants ////////////////////////
+def final ATTR_SWITCH = "generic.switch"
+def final VALUE_CHANGES = "valueChanges"
+
+///////////////// Driver Lifecycle ////////////////
+
+onAdded {
+   log.debug "IPCD Generic Switch Device Added."
+   
+   DevicePower.sourcechanged        ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+   
+   Switch.state                     Switch.STATE_OFF
+   Switch.statechanged              ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+}
+
+onConnected {
+   log.debug "IPCD Generic Switch1 Device Connected."
+   
+   Ipcd.Commands.getParameterValues("txnid", [ATTR_SWITCH])
+}
+
+onDisconnected {
+   log.debug "IPCD Generic Switch1 Device Disconnected."
+}
+
+onRemoved {
+   Ipcd.Commands.factoryReset()
+   log.debug "IPCD Generic Switch1 Device Removed."
+}
+
+/////////////// Capability Attribute Closures ///////////////////
+
+setAttributes('swit') {
+   log.debug "IPCD Generic Switch1 driver received 'swit' set Attribute message " + message
+   def attributes = message.attributes
+   for (attribute in attributes) {
+      switch(attribute.key) {
+         case Switch.state:
+            if (attribute.value == 'ON') {
+               Ipcd.Commands.setParameterValues("txnid", [ (ATTR_SWITCH) : "on" ])
+            } else { 
+               Ipcd.Commands.setParameterValues("txnid", [ (ATTR_SWITCH) : "off" ])
+            }
+         break;
+
+         default:
+            log.error "unrecognized attribute: " + attribute
+      }
+   }
+}
+
+///////////////// Protocol Messages ///////////////////////////
+
+onIpcdMessage.event {
+   log.debug("Got event from IPCD Device " + message)
+   def eventMap = message.mapify()
+   if (eventMap.containsKey(VALUE_CHANGES)) {
+      def valueChanges = eventMap[VALUE_CHANGES]
+      for (valueChange in valueChanges) {
+         if (valueChange["parameter"] == ATTR_SWITCH) {
+            def prevState = Switch.state.get()
+            Switch.state( valueChange["value"] == 'on' ? Switch.STATE_ON : Switch.STATE_OFF )
+            if (Switch.state.get() != prevState) {
+               Switch.statechanged( new Date())
+            }
+         }
+      }
+   }
+}
+
+onIpcdMessage.response.getParameterValues("success") {
+   log.debug("Got Response from IPCD Device " + message)
+   def response = message.mapify()["response"]
+   log.debug("Response contents from IPCD Device " + response)
+   if (response.containsKey(ATTR_SWITCH)) {
+      Switch.state( response[ATTR_SWITCH] == 'on' ? Switch.STATE_ON : Switch.STATE_OFF )
+   }
+}
+
+

--- a/platform/arcus-prodcat/src/main/resources/com/iris/prodcat/parser/prodcat_1.0.0.xsd
+++ b/platform/arcus-prodcat/src/main/resources/com/iris/prodcat/parser/prodcat_1.0.0.xsd
@@ -270,6 +270,7 @@
 
   <xs:simpleType name="vendorType">
     <xs:restriction base="xs:string">
+      <xs:enumeration value="Arcus"/>
       <xs:enumeration value="GE"/>
       <xs:enumeration value="Utilitech"/>
       <xs:enumeration value="Everspring"/>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <prodcat xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://arcus.com/prodcat_1.0.0">
   <brands>
+    <brand name="Arcus"/>
     <brand name="Aeotec by Aeon Labs"/>
     <brand name="Amazon"/>
     <brand name="Blink"/>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -76,7 +76,7 @@
     <category name="Voice Assistant"/>
   </categories>
   <products>
-    <product id="0c9a55" name="Generic Contact Sensor" shortname="Contact Sensor" screen="Contact" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
+    <product id="0c9a55" name="Generic Contact Sensor" shortname="Contact Sensor" screen="Contact" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="contact, door, window, sensor, security, alarmcontact, generic" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
         <categories>
             <category name="Cameras &amp; Sensors"/>
             <category name="Care"/>
@@ -102,7 +102,7 @@
             <population name="beta"/>
         </populations>
     </product>
-    <product id="0c9a56" name="Genric Switch" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
+    <product id="0c9a56" name="Generic Switch" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, generic" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
       <categories>
         <category name="Lights &amp; Switches"/>
       </categories>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -74,6 +74,50 @@
     <category name="Voice Assistant"/>
   </categories>
   <products>
+    <product id="0c9a55" name="Generic Contact Sensor" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Generic" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
+        <categories>
+            <category name="Lights &amp; Switches"/>
+        </categories>
+        <pair>
+            <step1 type="text" img="" text="Enter the Device ID" target="BRDG::IPCD" message="bridgesvc:RegisterDevice">
+                <input type="text" label="8-Character Code" name="IPCD:sn" minlen="8 maxlen="8" required="true"/>
+                <input type="hidden" name="IPCD:v1devicetype" value="GenericContactSensor"/>
+            </step1>
+        </pair>
+        <removal>
+            <step0 type="text" img="" text="TODO"/>
+        </removal>
+        <reset>
+            <step1 type="text" img="" text="TODO"/>
+        </reset>
+        <populations>
+            <population name="general"/>
+            <population name="qa"/>
+            <population name="beta"/>
+        </populations>
+    </product>
+    <product id="0c9a56" name="Genric Switch" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Generic" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
+      <categories>
+        <category name="Lights &amp; Switches"/>
+      </categories>
+      <pair>
+        <step1 type="text" img="" text="Enter the Device ID" target="BRDG::IPCD" message="bridgesvc:RegisterDevice">
+          <input type="text" label="8-Character Code" name="IPCD:sn" minlen="8" maxlen="8" required="true"/>
+          <input type="hidden" name="IPCD:v1devicetype" value="GenericSwitch"/>
+        </step1>
+      </pair>
+      <removal>
+        <step0 type="text" img="" text="TODO"/>
+      </removal>
+      <reset>
+        <step1 type="text" img="" text="TODO"/>
+      </reset>
+      <populations>
+        <population name="general"/>
+        <population name="qa"/>
+        <population name="beta"/>
+      </populations>
+    </product>
     <product id="0c9a66" name="Plug-In Switch (12719 Z-Wave)" shortname="Plug-In Switch" screen="Switch" description="" manufacturer="Jasco" installManualUrl="https://byjasco.com/sites/default/files/product/manuals/12719%20EnFrSp%20QStart%20V1%20081814.pdf" vendor="GE" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="https://youtu.be/NNOZR9qrmpQ" keywords="GE, Jasco, indoor, module, control, outlet, plug, switch, energy, 120, volt, 15, amp, power, zwave, 12719" ota="No" protofamily="Z-Wave" added="2015-06-29T22:56:59-0600" lastchanged="2018-03-08T10:27:00-0600">
       <categories>
         <category name="Lights &amp; Switches"/>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -75,7 +75,7 @@
     <category name="Voice Assistant"/>
   </categories>
   <products>
-    <product id="0c9a55" name="Generic Contact Sensor" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Generic" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
+    <product id="0c9a55" name="Generic Contact Sensor" shortname="Contact Sensor" screen="Contact" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
         <categories>
             <category name="Lights &amp; Switches"/>
         </categories>
@@ -86,7 +86,7 @@
             </step1>
         </pair>
         <removal>
-            <step0 type="text" img="" text="TODO"/>
+          <step1 type="text" img="" text="Please wait for the device to be removed from the Arcus Cloud Platform. &#xA;          &#x9;If this takes longer than a few seconds, consider factory resetting the device."/>
         </removal>
         <reset>
             <step1 type="text" img="" text="TODO"/>
@@ -97,7 +97,7 @@
             <population name="beta"/>
         </populations>
     </product>
-    <product id="0c9a56" name="Genric Switch" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Generic" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
+    <product id="0c9a56" name="Genric Switch" shortname="Light Switch" screen="Switch" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
       <categories>
         <category name="Lights &amp; Switches"/>
       </categories>
@@ -108,7 +108,7 @@
         </step1>
       </pair>
       <removal>
-        <step0 type="text" img="" text="TODO"/>
+        <step1 type="text" img="" text="Please wait for the device to be removed from the Arcus Cloud Platform. &#xA;          &#x9;If this takes longer than a few seconds, consider factory resetting the device."/>
       </removal>
       <reset>
         <step1 type="text" img="" text="TODO"/>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -15,6 +15,7 @@
     <brand name="FortrezZ"/>
     <brand name="Gatehouse"/>
     <brand name="GE"/>
+    <brand name="Generic"/>
     <brand name="Genie"/>
     <brand name="GoControl"/>
     <brand name="Google"/>
@@ -80,7 +81,7 @@
         </categories>
         <pair>
             <step1 type="text" img="" text="Enter the Device ID" target="BRDG::IPCD" message="bridgesvc:RegisterDevice">
-                <input type="text" label="8-Character Code" name="IPCD:sn" minlen="8 maxlen="8" required="true"/>
+                <input type="text" label="8-Character Code" name="IPCD:sn" minlen="8" maxlen="8" required="true"/>
                 <input type="hidden" name="IPCD:v1devicetype" value="GenericContactSensor"/>
             </step1>
         </pair>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -78,7 +78,11 @@
   <products>
     <product id="0c9a55" name="Generic Contact Sensor" shortname="Contact Sensor" screen="Contact" description="" manufacturer="Arcus" installManualUrl="" vendor="Arcus" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="switch, energy, power, insteon" ota="No" protofamily="IPCD" pairingMode="IPCD" hubrequired="false" added="2019-09-24T19:56:50-0600" lastchanged="2019-09-24T19:56:50-0600">
         <categories>
-            <category name="Lights &amp; Switches"/>
+            <category name="Cameras &amp; Sensors"/>
+            <category name="Care"/>
+            <category name="Doors &amp; Locks"/>
+            <category name="Security"/>
+            <category name="Windows &amp; Blinds"/>
         </categories>
         <pair>
             <step1 type="text" img="" text="Enter the Device ID" target="BRDG::IPCD" message="bridgesvc:RegisterDevice">


### PR DESCRIPTION
Add a generic IPCD Switch and Contact sensor, for use in extending Arcus driver support via the IPCD protocol. This allows many devices to be written in Python or another language of the author's choosing, without having to write platform-specific drivers in Java.