### PR TITLE
Allow firmware updates to be configured per model, in addition to version ranges

### DIFF
--- a/platform/arcus-containers/hub-bridge/src/dist/conf/firmware.xml
+++ b/platform/arcus-containers/hub-bridge/src/dist/conf/firmware.xml
@@ -3,9 +3,9 @@
 
    <metadata version="2017-12-05T00:00:00" publisher="Human"/>
    
-   <firmware min="2.0.0.024" max="2.0.2.016" target="IH200/hubOS_2.2.0.008" population="general, qa, beta"/>
+   <firmware model="IH200" min="2.0.0.024" max="2.0.2.016" target="IH200/hubOS_2.2.0.008" population="general, qa, beta"/>
    
    <!-- FIXME: Set correct v3 versions here, once we finalize them -->
-   <firmware min="3.0.0.001" max="3.0.1.018" target="IH30x/hubOSv3_3.0.1.025" population="general, qa, beta"/>
+   <firmware model="IH304" min="3.0.0.001" max="3.0.1.018" target="IH30x/hubOSv3_3.0.1.025" population="general, qa, beta"/>
    
 </firmwares>

--- a/platform/arcus-containers/hub-bridge/src/main/java/com/iris/hubcom/server/message/HubConnectedHandler.java
+++ b/platform/arcus-containers/hub-bridge/src/main/java/com/iris/hubcom/server/message/HubConnectedHandler.java
@@ -207,7 +207,7 @@ public class HubConnectedHandler extends DirectMessageHandler {
       String firmwareVersion = HubAdvancedCapability.getOsver(request);
       String agentVersion = HubAdvancedCapability.getAgentver(request);
 
-      log.info("{} firmware versions: model={}, hwVer={}, osVer={}, agentVer={}", hub.getModel(), hub.getId(), hardwareVersion, firmwareVersion, agentVersion);
+      log.info("{} firmware versions: model={}, hwVer={}, osVer={}, agentVer={}", hub.getId(), hub.getModel(), hardwareVersion, firmwareVersion, agentVersion);
 
       if (firmwareVersion == null || firmwareVersion.equalsIgnoreCase("unknown")) {
          log.warn("Hub [{}] firmware version is unkown.");

--- a/platform/arcus-containers/hub-bridge/src/main/java/com/iris/hubcom/server/message/HubConnectedHandler.java
+++ b/platform/arcus-containers/hub-bridge/src/main/java/com/iris/hubcom/server/message/HubConnectedHandler.java
@@ -202,12 +202,12 @@ public class HubConnectedHandler extends DirectMessageHandler {
 
 
 
-private boolean upgradeIfNeeded(Session session, Hub hub, MessageBody request) {
+   private boolean upgradeIfNeeded(Session session, Hub hub, MessageBody request) {
       String hardwareVersion = HubAdvancedCapability.getHardwarever(request);
       String firmwareVersion = HubAdvancedCapability.getOsver(request);
       String agentVersion = HubAdvancedCapability.getAgentver(request);
 
-      log.info("{} firmware versions: hwVer={}, osVer={}, agentVer={}", hub.getId(), hardwareVersion, firmwareVersion, agentVersion);
+      log.info("{} firmware versions: model={}, hwVer={}, osVer={}, agentVer={}", hub.getModel(), hub.getId(), hardwareVersion, firmwareVersion, agentVersion);
 
       if (firmwareVersion == null || firmwareVersion.equalsIgnoreCase("unknown")) {
          log.warn("Hub [{}] firmware version is unkown.");
@@ -217,7 +217,7 @@ private boolean upgradeIfNeeded(Session session, Hub hub, MessageBody request) {
       //require upgrade
       hubRegistrationRegistry.online(hub.getId());
       
-      MessageBody msgBody = hubRegistrationRegistry.upgradeIfNeeded(hub.getId(), firmwareVersion, hubPopulationResolver.getPopulationNameForHub(hub));
+      MessageBody msgBody = hubRegistrationRegistry.upgradeIfNeeded(hub, firmwareVersion, hubPopulationResolver.getPopulationNameForHub(hub));
       if (msgBody == null) {
     	  return false;
       }

--- a/platform/arcus-lib/src/main/java/com/iris/firmware/FirmwareParser.java
+++ b/platform/arcus-lib/src/main/java/com/iris/firmware/FirmwareParser.java
@@ -52,6 +52,7 @@ public class FirmwareParser implements ResourceParser<List<FirmwareUpdate>> {
    private static final String ELEMENT_FIRMWARE = "firmware";
    private static final String ATTR_MIN = "min";
    private static final String ATTR_MAX = "max";
+   private static final String ATTR_MODEL = "model";
    private static final String ATTR_TARGET = "target";
    private static final String ATTR_POPULATION = "population";
    
@@ -84,6 +85,7 @@ public class FirmwareParser implements ResourceParser<List<FirmwareUpdate>> {
    
    private FirmwareUpdate buildFirmwareUpdate(Node firmwareNode) {
       Element firmware = (Element)firmwareNode;
+      String model = firmware.getAttribute(ATTR_MODEL);
       String min = firmware.getAttribute(ATTR_MIN);
       String max = firmware.getAttribute(ATTR_MAX);
       String target = firmware.getAttribute(ATTR_TARGET);
@@ -92,7 +94,7 @@ public class FirmwareParser implements ResourceParser<List<FirmwareUpdate>> {
       	throw new RuntimeException("Firmware XML is invalid because population attribute is missing.");
       }
       
-      return new FirmwareUpdate(min, max, target, populations);
+      return new FirmwareUpdate(model, min, max, target, populations);
    }
    
    private Set<String> getPopulations(String populationStr) {

--- a/platform/arcus-lib/src/main/java/com/iris/firmware/FirmwareUpdate.java
+++ b/platform/arcus-lib/src/main/java/com/iris/firmware/FirmwareUpdate.java
@@ -16,6 +16,7 @@
 package com.iris.firmware;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -25,14 +26,16 @@ import com.iris.model.Version;
 
 public class FirmwareUpdate {
    public enum MatchType { NONE, VERSION, VERSION_AND_POPULATION }
-   
+   private final String model;
    private final Version min;
    private final Version max;
    private final String target;
    private final Set<String> populations;
    
-   public FirmwareUpdate(String min, String max, String target, Set<String> populations) {
+   public FirmwareUpdate(String model, String min, String max, String target, Set<String> populations) {
+      Preconditions.checkArgument(!StringUtils.isEmpty(model), "The firmware hardware model cannot be empty");
       Preconditions.checkArgument(!StringUtils.isEmpty(target), "The firmware target cannot be empty");
+      this.model = model;
       this.min = Version.fromRepresentation(min);
       this.max = Version.fromRepresentation(max);
       Preconditions.checkArgument(this.min.compareTo(this.max) >= 0, "The max version cannot be less than the min version for target " + target);
@@ -98,6 +101,10 @@ public class FirmwareUpdate {
    public Set<String> getPopulations() {
       return populations;
    }
+
+   public String getModel() {
+      return model;
+   }
    
    private boolean matchVersion(Version version) {
       return (min.compareTo(version) >= 0) && (max.compareTo(version) <= 0);
@@ -114,47 +121,20 @@ public class FirmwareUpdate {
    }
 
    @Override
-   public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((max == null) ? 0 : max.hashCode());
-      result = prime * result + ((min == null) ? 0 : min.hashCode());
-      result = prime * result
-            + ((populations == null) ? 0 : populations.hashCode());
-      result = prime * result + ((target == null) ? 0 : target.hashCode());
-      return result;
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      FirmwareUpdate that = (FirmwareUpdate) o;
+      return model.equals(that.model) &&
+              min.equals(that.min) &&
+              max.equals(that.max) &&
+              target.equals(that.target) &&
+              populations.equals(that.populations);
    }
 
    @Override
-   public boolean equals(Object obj) {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      FirmwareUpdate other = (FirmwareUpdate) obj;
-      if (max == null) {
-         if (other.max != null)
-            return false;
-      } else if (!max.equals(other.max))
-         return false;
-      if (min == null) {
-         if (other.min != null)
-            return false;
-      } else if (!min.equals(other.min))
-         return false;
-      if (populations == null) {
-         if (other.populations != null)
-            return false;
-      } else if (!populations.equals(other.populations))
-         return false;
-      if (target == null) {
-         if (other.target != null)
-            return false;
-      } else if (!target.equals(other.target))
-         return false;
-      return true;
+   public int hashCode() {
+      return Objects.hash(model, min, max, target, populations);
    }
 }
 

--- a/platform/arcus-lib/src/main/java/com/iris/firmware/FirmwareUpdateResolver.java
+++ b/platform/arcus-lib/src/main/java/com/iris/firmware/FirmwareUpdateResolver.java
@@ -19,12 +19,12 @@ import com.iris.model.Version;
 
 public interface FirmwareUpdateResolver {
    
-   FirmwareResult getTargetForVersion(String version);
+   FirmwareResult getTargetForVersion(String model, String version);
    
-   FirmwareResult getTargetForVersion(Version version);
+   FirmwareResult getTargetForVersion(String model, Version version);
    
-   FirmwareResult getTargetForVersion(String version, String population);
+   FirmwareResult getTargetForVersion(String model, String version, String population);
    
-   FirmwareResult getTargetForVersion(Version version, String population);
+   FirmwareResult getTargetForVersion(String model, Version version, String population);
 }
 

--- a/platform/arcus-lib/src/main/java/com/iris/firmware/HubFirmwareURLBuilder.java
+++ b/platform/arcus-lib/src/main/java/com/iris/firmware/HubFirmwareURLBuilder.java
@@ -26,7 +26,7 @@ public class HubFirmwareURLBuilder implements FirmwareURLBuilder<Hub> {
 
    @Inject(optional = true)
    @Named("firmware.download.scheme")
-   private String firmwareDownloadScheme = "http";
+   private String firmwareDownloadScheme = "https";
 
    @Inject
    @Named("firmware.download.host")

--- a/platform/arcus-lib/src/main/java/com/iris/platform/hub/registration/HubRegistrationRegistry.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/hub/registration/HubRegistrationRegistry.java
@@ -112,26 +112,26 @@ public class HubRegistrationRegistry  {
 		}
 	}
 	
-	public FirmwareResult getTargetFirmware(String currentFirmwareVersion, String population) {
-	   if(StringUtils.isNotEmpty(population)) {
-	      return resolver.getTargetForVersion(currentFirmwareVersion, population);
-	   }else{
-	      return resolver.getTargetForVersion(currentFirmwareVersion);
+	public FirmwareResult getTargetFirmware(String model, String currentFirmwareVersion, String population) {
+	   if (StringUtils.isNotEmpty(population)) {
+	      return resolver.getTargetForVersion(model, currentFirmwareVersion, population);
+	   } else {
+	      return resolver.getTargetForVersion(model, currentFirmwareVersion);
 	   }
 	}
 	
 	@Nullable
-	public MessageBody upgrade(String hubId, String currentFirmwareVersion, String targetFirmware, String priority, boolean showLed) {
+	public MessageBody upgrade(Hub hub, String currentFirmwareVersion, String targetFirmware, String priority, boolean showLed) {
 
       Instant now = Instant.now();
-      HubRegistration curHubReg = findHubRegistration(hubId);
+      HubRegistration curHubReg = findHubRegistration(hub.getId());
 
       if (curHubReg != null && RegistrationState.APPLYING.equals(curHubReg.getState()) && targetFirmware != null) {
          // state is APPLYING, but firmwareVersion still did not reach
          // targetFirmware version.  Will log a warning, but do not update the error in hub_registration
          logger.warn(
                "Hub [{}] is at firmware version [{}], but registration state is APPLYING which should not happen.  Will try sending upgrade request again.",
-               hubId, currentFirmwareVersion);
+               hub.getId(), currentFirmwareVersion);
       }
       
 
@@ -144,10 +144,9 @@ public class HubRegistrationRegistry  {
          curHubReg.setDownloadProgress(0);
          hubRegistrationDao.save(curHubReg);
       }
-      String firmwareURL = urlBuilder.buildURL(hubTemplate, targetFirmware);
+      String firmwareURL = urlBuilder.buildURL(hub, targetFirmware);
 
-      logger.debug("Sending firmware update request with url: {} to hub: {}", firmwareURL, hubId);
-      
+      logger.debug("Sending firmware update request with url: {} to hub: {}", firmwareURL, hub.getId());
       
       MessageBody upgrade = HubAdvancedCapability.FirmwareUpdateRequest.builder()
     		.withUrl(firmwareURL)
@@ -159,26 +158,26 @@ public class HubRegistrationRegistry  {
 	}
 	
 	@Nullable
-	public MessageBody upgradeIfNeeded(String hubId, String currentFirmwareVersion) {
-	   return upgradeIfNeeded(hubId, currentFirmwareVersion, null);
+	public MessageBody upgradeIfNeeded(Hub hub, String currentFirmwareVersion) {
+	   return upgradeIfNeeded(hub, currentFirmwareVersion, null);
 	}
 
 	@Nullable
-	public MessageBody upgradeIfNeeded(String hubId, String currentFirmwareVersion, String population) {
-		FirmwareResult targetFirmwareResult = getTargetFirmware(currentFirmwareVersion, population);		
+	public MessageBody upgradeIfNeeded(Hub hub, String currentFirmwareVersion, String population) {
+		FirmwareResult targetFirmwareResult = getTargetFirmware(hub.getModel(), currentFirmwareVersion, population);
 
-		HubRegistration curHubReg = findHubRegistration(hubId);
+		HubRegistration curHubReg = findHubRegistration(hub.getId());
 		
 		if (targetFirmwareResult.getResult() != FirmwareResult.Result.UPGRADE_NEEDED) {
-		   if (targetFirmwareResult.getResult() == FirmwareResult.Result.UPGRADE_NOT_POSSIBLE) {
-   			logger.info("Hub [{}] is at firmware version [{}] which can't be upgraded", hubId, currentFirmwareVersion);
-   			firmwareUpgradeFailed(curHubReg, HubRegistrationErrors.VERSION_CAN_NOT_UPGRADE.getCode(),
-   					 HubRegistrationErrors.VERSION_CAN_NOT_UPGRADE.getMessage(currentFirmwareVersion));
-		   }
+			if (targetFirmwareResult.getResult() == FirmwareResult.Result.UPGRADE_NOT_POSSIBLE) {
+				logger.info("Hub [{}] is at firmware version [{}] which can't be upgraded", hub.getId(), currentFirmwareVersion);
+				firmwareUpgradeFailed(curHubReg, HubRegistrationErrors.VERSION_CAN_NOT_UPGRADE.getCode(),
+						HubRegistrationErrors.VERSION_CAN_NOT_UPGRADE.getMessage(currentFirmwareVersion));
+			}
 			return null;
 		}
 
-		return upgrade(hubId, currentFirmwareVersion, targetFirmwareResult.getTarget(), HubAdvancedCapability.FirmwareUpdateRequest.PRIORITY_URGENT, true);
+		return upgrade(hub, currentFirmwareVersion, targetFirmwareResult.getTarget(), HubAdvancedCapability.FirmwareUpdateRequest.PRIORITY_URGENT, true);
 	}
 
 	public boolean updateFirmwareUpgradeProcess(String hubId, String upgradeStatus, Double percentDone) {

--- a/platform/arcus-lib/src/main/java/com/iris/platform/hub/registration/HubRegistrationRegistry.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/hub/registration/HubRegistrationRegistry.java
@@ -156,7 +156,7 @@ public class HubRegistrationRegistry  {
             .build();
       return upgrade;
 	}
-	
+
 	@Nullable
 	public MessageBody upgradeIfNeeded(Hub hub, String currentFirmwareVersion) {
 	   return upgradeIfNeeded(hub, currentFirmwareVersion, null);

--- a/platform/arcus-lib/src/main/resources/firmware.xsd
+++ b/platform/arcus-lib/src/main/resources/firmware.xsd
@@ -25,6 +25,7 @@
 	</xs:complexType>
 	
 	<xs:complexType name="firmwareType">
+	   <xs:attribute name="model" type="xs:string" use="required" />
 	   <xs:attribute name="min" type="xs:string" use="required" />
 	   <xs:attribute name="max" type="xs:string" use="required" />
 	   <xs:attribute name="target" type="xs:string" use="required" />

--- a/platform/arcus-lib/src/test/java/com/iris/firmware/FirmwareTestCase.java
+++ b/platform/arcus-lib/src/test/java/com/iris/firmware/FirmwareTestCase.java
@@ -17,7 +17,6 @@ package com.iris.firmware;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;

--- a/platform/arcus-lib/src/test/java/com/iris/firmware/TestFirmwareParser.java
+++ b/platform/arcus-lib/src/test/java/com/iris/firmware/TestFirmwareParser.java
@@ -99,6 +99,16 @@ public class TestFirmwareParser extends FirmwareTestCase {
    }
 
    @Test
+   public void testFirmwareMissingModel() throws Exception {
+      try {
+         loadFirmwares("firmware-missing-model.xml");
+         Assert.fail("Shouldn't have been able to parse the firmware update.");
+      }
+      catch(RuntimeException ex) {
+         Assert.assertTrue(ex.getCause().getCause().getMessage().startsWith("The firmware hardware model cannot be empty"));
+      }
+   }
+   @Test
    public void testFirmwareReverseMinMax() throws Exception {
       try {
          loadFirmwares("firmware-reverse-min-max.xml");

--- a/platform/arcus-lib/src/test/java/com/iris/firmware/TestHubFirmwareURLBuilder.java
+++ b/platform/arcus-lib/src/test/java/com/iris/firmware/TestHubFirmwareURLBuilder.java
@@ -29,7 +29,7 @@ public class TestHubFirmwareURLBuilder {
    public void testFirmwareURLBuild() {
       Hub hub = new Hub();
 
-      assertEquals("http://null/IH200/hubOS_2.0.0.017.bin", builder.buildURL(hub, "IH200/hubOS_2.0.0.017"));
+      assertEquals("https://null/IH200/hubOS_2.0.0.017.bin", builder.buildURL(hub, "IH200/hubOS_2.0.0.017"));
    }
 
 }

--- a/platform/arcus-lib/src/test/java/com/iris/firmware/TestXMLFirmwareResolver.java
+++ b/platform/arcus-lib/src/test/java/com/iris/firmware/TestXMLFirmwareResolver.java
@@ -27,23 +27,23 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
    public void testResolveGeneralInValidRange() throws Exception {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
-      FirmwareResult result = resolver.getTargetForVersion("2.0.0.024");
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.0.0.024");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.0.006", result.getTarget());
       
-      result = resolver.getTargetForVersion(Version.fromRepresentation("2.0.0.124"));
+      result = resolver.getTargetForVersion("IH200", Version.fromRepresentation("2.0.0.124"));
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.0.006", result.getTarget());
       
-      result = resolver.getTargetForVersion("2.0.0.024", Population.NAME_GENERAL);
+      result = resolver.getTargetForVersion("IH200", "2.0.0.024", Population.NAME_GENERAL);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.0.006", result.getTarget());
       
-      result = resolver.getTargetForVersion("2.1.0.004");
+      result = resolver.getTargetForVersion("IH200", "2.1.0.004");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.0.006", result.getTarget());
       
-      result = resolver.getTargetForVersion("3.1.0.023");
+      result = resolver.getTargetForVersion("IH300", "3.1.0.023");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubOS_3.1.1.002", result.getTarget());
    }
@@ -54,31 +54,31 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       
       // This is a weird test case because exceeding the max 2.0.x but it doesn't qualify for upgrading
       // to a 2.1.x version. 
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.002", Population.NAME_GENERAL);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.002", Population.NAME_GENERAL);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());
       
       // This is a weird test case because exceeding the max 2.0.x but it doesn't qualify for upgrading
       // to a 2.1.x version. 
-      result = resolver.getTargetForVersion("2.1.0.002");
+      result = resolver.getTargetForVersion("IH200", "2.1.0.002");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());
       
-      result = resolver.getTargetForVersion("2.0.0.023");
+      result = resolver.getTargetForVersion("IH200", "2.0.0.023");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_POSSIBLE, result.getResult());
       Assert.assertEquals(null, result.getTarget());
       
       // This is a weird test case because exceeding the max 2.0.x but it doesn't qualify for upgrading
       // to a 2.1.x version. 
-      result = resolver.getTargetForVersion("2.0.1.005");
+      result = resolver.getTargetForVersion("IH200", "2.0.1.005");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());    
       
-      result = resolver.getTargetForVersion("3.1.0.001");
+      result = resolver.getTargetForVersion("IH300", "3.1.0.001");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_POSSIBLE, result.getResult());
       Assert.assertEquals(null, result.getTarget());
       
-      result = resolver.getTargetForVersion("3.1.1.002");
+      result = resolver.getTargetForVersion("IH300", "3.1.1.002");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());
    }
@@ -92,11 +92,11 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       
       
       // Check matching invalid ranges (wrong population)
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.006", Population.NAME_GENERAL);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.006", Population.NAME_GENERAL);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());
       
-      result = resolver.getTargetForVersion("2.1.0.007", Population.NAME_GENERAL);
+      result = resolver.getTargetForVersion("IH200", "2.1.0.007", Population.NAME_GENERAL);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());
    }
@@ -106,7 +106,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match QA Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.0.0.027", Population.NAME_QA);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.0.0.027", Population.NAME_QA);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.0.006", result.getTarget());      
    }
@@ -116,7 +116,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match QA Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.004", Population.NAME_QA);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.004", Population.NAME_QA);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.1.000", result.getTarget());      
    }
@@ -126,7 +126,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match QA Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.006", Population.NAME_QA);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.006", Population.NAME_QA);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubOS_2.1.2.000", result.getTarget());      
    }
@@ -136,7 +136,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match QA Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.0.0.023", Population.NAME_QA);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.0.0.023", Population.NAME_QA);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_POSSIBLE, result.getResult());
       Assert.assertEquals(null, result.getTarget());      
    }
@@ -146,7 +146,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match QA Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.008", Population.NAME_QA);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.008", Population.NAME_QA);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_NEEDED, result.getResult());
       Assert.assertEquals(null, result.getTarget());      
    }
@@ -156,7 +156,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match Beta Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.0.0.999", "beta");
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.0.0.999", "beta");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.0.006", result.getTarget());      
    }
@@ -166,7 +166,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match Beta Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.004", "beta");
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.004", "beta");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubBL_2.1.1.000", result.getTarget());      
    }
@@ -176,7 +176,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match Beta Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.1.0.006", "beta");
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.1.0.006", "beta");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("hubOS_2.1.2.001", result.getTarget());      
    }
@@ -186,7 +186,7 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-cases.xml");
       
       // Match Beta Population Entry
-      FirmwareResult result = resolver.getTargetForVersion("2.0.0.023", "beta");
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "2.0.0.023", "beta");
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NOT_POSSIBLE, result.getResult());
       Assert.assertEquals(null, result.getTarget());      
    }
@@ -196,12 +196,12 @@ public class TestXMLFirmwareResolver extends FirmwareTestCase {
       FirmwareUpdateResolver resolver = getResolver("firmware-test.xml");
       
       // Match First Firmware Entry
-      FirmwareResult result = resolver.getTargetForVersion("1.0.0.001", Population.NAME_GENERAL);
+      FirmwareResult result = resolver.getTargetForVersion("IH200", "1.0.0.001", Population.NAME_GENERAL);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("HubOS_2.1.0.006", result.getTarget());
       
       // Match Second Firmware Entry
-      result = resolver.getTargetForVersion("2.1.0.010", Population.NAME_GENERAL);
+      result = resolver.getTargetForVersion("IH200", "2.1.0.010", Population.NAME_GENERAL);
       Assert.assertEquals(FirmwareResult.Result.UPGRADE_NEEDED, result.getResult());
       Assert.assertEquals("HubBL_2.1.1.002", result.getTarget());
    }

--- a/platform/arcus-lib/src/test/resources/firmware-cases.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-cases.xml
@@ -3,16 +3,16 @@
 
    <metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <firmware min="2.0.0.024" max="2.0.0.999" target="hubBL_2.1.0.006" population="general, qa, beta"/>
+   <firmware model="IH200" min="2.0.0.024" max="2.0.0.999" target="hubBL_2.1.0.006" population="general, qa, beta"/>
    
-   <firmware min="2.1.0.003" max="2.1.0.005" target="hubBL_2.1.0.006" population="general"/>
+   <firmware model="IH200" min="2.1.0.003" max="2.1.0.005" target="hubBL_2.1.0.006" population="general"/>
    
-   <firmware min="2.1.0.003" max="2.1.0.005" target="hubBL_2.1.1.000" population="qa, beta"/>
+   <firmware model="IH200" min="2.1.0.003" max="2.1.0.005" target="hubBL_2.1.1.000" population="qa, beta"/>
    
-   <firmware min="2.1.0.006" max="2.1.0.006" target="hubOS_2.1.2.000" population="qa" />
+   <firmware model="IH200" min="2.1.0.006" max="2.1.0.006" target="hubOS_2.1.2.000" population="qa" />
+
+   <firmware model="IH200" min="2.1.0.006" max="2.1.0.008" target="hubOS_2.1.2.001" population="beta" />
    
-   <firmware min="2.1.0.006" max="2.1.0.008" target="hubOS_2.1.2.001" population="beta" />
-   
-   <firmware min="3.1.0.004" max="3.1.0.054" target="hubOS_3.1.1.002" population="general, qa, beta"/>
+   <firmware model="IH300" min="3.1.0.004" max="3.1.0.054" target="hubOS_3.1.1.002" population="general, qa, beta"/>
    
 </firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-duplicate-overlap.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-duplicate-overlap.xml
@@ -3,10 +3,10 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,alpha,beta"/>
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,alpha,beta"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubBL_2.1.1.002" population="general,alpha,beta"/>
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubBL_2.1.1.002" population="general,alpha,beta"/>
    
-   <f:firmware min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="alpha,beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="alpha,beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-exact-overlap.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-exact-overlap.xml
@@ -3,10 +3,10 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,qa,beta"/>
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,qa,beta"/>
    
-   <f:firmware min="2.1.0.005" max="2.1.0.026" target="HubBL_2.1.1.002" population="general,qa,beta"/>
+   <f:firmware model="IH200" min="2.1.0.005" max="2.1.0.026" target="HubBL_2.1.1.002" population="general,qa,beta"/>
    
-   <f:firmware min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="qa,beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="qa,beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-missing-max.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-missing-max.xml
@@ -3,6 +3,6 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="2.1.0.009" max="" target="HubOS_2.1.2.0" population="alpha,beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="" target="HubOS_2.1.2.0" population="alpha,beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-missing-min.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-missing-min.xml
@@ -3,6 +3,6 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="" max="2.1.0.005" target="HubOS_2.1.0.006" population="alpha" />
+   <f:firmware model="IH200" min="" max="2.1.0.005" target="HubOS_2.1.0.006" population="alpha" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-missing-model.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-missing-model.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <f:firmwares xmlns:f="http://arcus.com/firmware_1.0.0">
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.002" target="" population="alpha,beta" />
+   <f:firmware model="" min="" max="2.1.0.005" target="HubOS_2.1.0.006" population="alpha" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-overlap-alpha.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-overlap-alpha.xml
@@ -3,14 +3,14 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general, qa,beta" />
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general, qa,beta" />
    
-   <f:firmware min="2.1.0.005" max="2.1.0.026" target="HubBL_2.1.1.002" population="general, qa,beta"/>
+   <f:firmware model="IH200" min="2.1.0.005" max="2.1.0.026" target="HubBL_2.1.1.002" population="general, qa,beta"/>
    
-   <f:firmware min="2.1.0.009" max="2.1.1.003" target="HubOS_2.1.2.0" population="qa" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.003" target="HubOS_2.1.2.0" population="qa" />
    
-   <f:firmware min="2.1.0.009" max="2.1.1.001" target="HubOS_2.1.2.0" population="beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.001" target="HubOS_2.1.2.0" population="beta" />
    
-   <f:firmware min="2.1.1.002" max="2.1.1.012" target="HubOS_2.1.2.1" population="qa, beta" />
+   <f:firmware model="IH200" min="2.1.1.002" max="2.1.1.012" target="HubOS_2.1.2.1" population="qa, beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-overlap-beta.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-overlap-beta.xml
@@ -3,12 +3,12 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general, qa, beta"/>
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general, qa, beta"/>
    
-   <f:firmware min="2.1.0.006" max="2.1.0.026" target="HubBL_2.1.1.002" population="general, qa, beta"/>
+   <f:firmware model="IH200" min="2.1.0.006" max="2.1.0.026" target="HubBL_2.1.1.002" population="general, qa, beta"/>
    
-   <f:firmware min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="beta" />
    
-   <f:firmware min="2.1.1.002" max="2.1.1.015" target="HubOS_2.1.2.0" population="beta" />
+   <f:firmware model="IH200" min="2.1.1.002" max="2.1.1.015" target="HubOS_2.1.2.0" population="beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-real.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-real.xml
@@ -3,7 +3,7 @@
   
    <metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <firmware min="2.0.0.024" max="2.0.0.999" target="hubBL_2.1.0.006" population="general,qa,beta" />
-   <firmware min="2.1.0.003" max="2.1.0.005" target="hubBL_2.1.0.006" population="general,qa,beta" />
+   <firmware model="IH200" min="2.0.0.024" max="2.0.0.999" target="hubBL_2.1.0.006" population="general,qa,beta" />
+   <firmware model="IH200" min="2.1.0.003" max="2.1.0.005" target="hubBL_2.1.0.006" population="general,qa,beta" />
    
 </firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-reverse-min-max.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-reverse-min-max.xml
@@ -3,6 +3,6 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="2.2.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="alpha,beta" />
+   <f:firmware model="IH200" min="2.2.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="alpha,beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-simple-overlap.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-simple-overlap.xml
@@ -3,10 +3,10 @@
 
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,qa,beta"/>
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,qa,beta"/>
    
-   <f:firmware min="2.0.0.009" max="2.1.0.026" target="HubBL_2.1.1.002" population="general,qa"/>
+   <f:firmware model="IH200" min="2.0.0.009" max="2.1.0.026" target="HubBL_2.1.1.002" population="general,qa"/>
    
-   <f:firmware min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="qa,beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="qa,beta" />
    
 </f:firmwares>

--- a/platform/arcus-lib/src/test/resources/firmware-test.xml
+++ b/platform/arcus-lib/src/test/resources/firmware-test.xml
@@ -3,10 +3,10 @@
    
    <f:metadata version="2015-07-29T22:56:59" publisher="Jane Doe"/>
    
-   <f:firmware min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,qa,beta" />
+   <f:firmware model="IH200" min="1.0.0.0" max="2.1.0.005" target="HubOS_2.1.0.006" population="general,qa,beta" />
    
-   <f:firmware min="2.1.0.009" max="2.1.0.026" target="HubBL_2.1.1.002" population="general" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.0.026" target="HubBL_2.1.1.002" population="general" />
    
-   <f:firmware min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="qa,beta" />
+   <f:firmware model="IH200" min="2.1.0.009" max="2.1.1.002" target="HubOS_2.1.2.0" population="qa,beta" />
    
 </f:firmwares>


### PR DESCRIPTION
Fixes #113, making the update process a bit safer for multiple hardware revisions being out in the wild.