### PR TITLE
Allow default service level to be configured (#61)

### DIFF
--- a/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/person/handlers/PromoteToAccountHandler.java
+++ b/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/person/handlers/PromoteToAccountHandler.java
@@ -58,10 +58,9 @@ public class PromoteToAccountHandler implements ContextualRequestMessageHandler<
    private final BeanAttributesTransformer<Place> placeTransform;
    private final PlatformMessageBus bus;
    private final PlacePopulationCacheManager populationCacheMgr;
-   private final ServiceLevel defaultServiceLevel;
 
    @Inject(optional = true) @Named("default.service.level")
-   private String defaultServiceLevelStr = "basic";
+   private String defaultServiceLevel = "basic";
 
    @Inject
    public PromoteToAccountHandler(
@@ -82,7 +81,6 @@ public class PromoteToAccountHandler implements ContextualRequestMessageHandler<
       this.placeTransform = placeTransform;
       this.bus = bus;
       this.populationCacheMgr = populationCacheMgr;
-      this.defaultServiceLevel= ServiceLevel.fromString(defaultServiceLevelStr);
    }
 
    @Override
@@ -116,7 +114,7 @@ public class PromoteToAccountHandler implements ContextualRequestMessageHandler<
 
          place = placeTransform.transform(PersonCapability.PromoteToAccountRequest.getPlace(body));
          place.setId(placeId);
-         place.setServiceLevel(defaultServiceLevel);
+         place.setServiceLevel(ServiceLevel.fromString(defaultServiceLevel));
          place.setAccount(account.getId());
          place.setPrimary(true);
          place = placeDao.create(place);

--- a/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/person/handlers/PromoteToAccountHandler.java
+++ b/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/person/handlers/PromoteToAccountHandler.java
@@ -25,6 +25,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.iris.capability.attribute.transform.BeanAttributesTransformer;
 import com.iris.core.dao.AccountDAO;
 import com.iris.core.dao.AuthorizationGrantDAO;
@@ -57,7 +58,10 @@ public class PromoteToAccountHandler implements ContextualRequestMessageHandler<
    private final BeanAttributesTransformer<Place> placeTransform;
    private final PlatformMessageBus bus;
    private final PlacePopulationCacheManager populationCacheMgr;
-   
+   private final ServiceLevel defaultServiceLevel;
+
+   @Inject(optional = true) @Named("default.service.level")
+   private String defaultServiceLevelStr = "basic";
 
    @Inject
    public PromoteToAccountHandler(
@@ -78,6 +82,7 @@ public class PromoteToAccountHandler implements ContextualRequestMessageHandler<
       this.placeTransform = placeTransform;
       this.bus = bus;
       this.populationCacheMgr = populationCacheMgr;
+      this.defaultServiceLevel= ServiceLevel.fromString(defaultServiceLevelStr);
    }
 
    @Override
@@ -111,7 +116,7 @@ public class PromoteToAccountHandler implements ContextualRequestMessageHandler<
 
          place = placeTransform.transform(PersonCapability.PromoteToAccountRequest.getPlace(body));
          place.setId(placeId);
-         place.setServiceLevel(ServiceLevel.BASIC);
+         place.setServiceLevel(defaultServiceLevel);
          place.setAccount(account.getId());
          place.setPrimary(true);
          place = placeDao.create(place);

--- a/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
@@ -36,6 +36,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.iris.capability.attribute.transform.BeanAttributesTransformer;
 import com.iris.core.dao.AccountDAO;
 import com.iris.core.dao.AuthorizationGrantDAO;
@@ -101,7 +102,11 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
    private final BeanAttributesTransformer<Person> personTransformer;
    private final BeanAttributesTransformer<Place> placeTransformer;
    private final PlatformMessageBus bus;
-   private final TimezonesChangeHelper timezoneHelper; 
+   private final TimezonesChangeHelper timezoneHelper;
+   private final ServiceLevel defaultServiceLevel;
+
+   @Inject(optional = true) @Named("default.service.level")
+   private String defaultServiceLevelStr = "basic";
 
    @Inject
    public CreateAccountHandler(
@@ -124,6 +129,7 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
       this.placeTransformer = placeTransformer;
       this.bus = bus;
       this.timezoneHelper = new TimezonesChangeHelper(timezonesMgr);
+      this.defaultServiceLevel= ServiceLevel.fromString(defaultServiceLevelStr);
    }
 
    @Override
@@ -206,7 +212,7 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
             timezoneHelper.processTimeZoneChanges(placeAttributes);
             placeTransformer.merge(place, placeAttributes);            
          }         
-         place.setServiceLevel(ServiceLevel.BASIC);
+         place.setServiceLevel(defaultServiceLevel);
          place.setAccount(account.getId());
          place.setPrimary(true);
          place = placeDao.create(place);

--- a/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
@@ -66,7 +66,6 @@ import org.slf4j.LoggerFactory;
 
 @Singleton
 public class CreateAccountHandler implements ContextualRequestMessageHandler<Account> {
-   private static final Logger logger = LoggerFactory.getLogger(CreateAccountHandler.class);
 
    public static final String EMAIL_IN_USE_ERROR_CODE = "error.signup.emailinuse";
    public static final String EMAIL_IN_USE_ERROR_MSG = "This email address is already in use. Please Sign In.";
@@ -108,7 +107,7 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
    private final TimezonesChangeHelper timezoneHelper;
 
    @Inject(optional = true) @Named("default.service.level")
-   private String defaultServiceLevelStr = "basic";
+   private String defaultServiceLevel = "basic";
 
    @Inject
    public CreateAccountHandler(
@@ -213,7 +212,7 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
             timezoneHelper.processTimeZoneChanges(placeAttributes);
             placeTransformer.merge(place, placeAttributes);            
          }
-         place.setServiceLevel(ServiceLevel.fromString(defaultServiceLevelStr));
+         place.setServiceLevel(ServiceLevel.fromString(defaultServiceLevel));
          place.setAccount(account.getId());
          place.setPrimary(true);
          place = placeDao.create(place);

--- a/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
@@ -106,7 +106,6 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
    private final BeanAttributesTransformer<Place> placeTransformer;
    private final PlatformMessageBus bus;
    private final TimezonesChangeHelper timezoneHelper;
-   private final ServiceLevel defaultServiceLevel;
 
    @Inject(optional = true) @Named("default.service.level")
    private String defaultServiceLevelStr = "basic";
@@ -132,8 +131,6 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
       this.placeTransformer = placeTransformer;
       this.bus = bus;
       this.timezoneHelper = new TimezonesChangeHelper(timezonesMgr);
-      this.defaultServiceLevel = ServiceLevel.fromString(defaultServiceLevelStr);
-      logger.info("Using {} as default service level", defaultServiceLevelStr);
    }
 
    @Override
@@ -215,8 +212,8 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
          if(placeAttributes != null && !placeAttributes.isEmpty()) {
             timezoneHelper.processTimeZoneChanges(placeAttributes);
             placeTransformer.merge(place, placeAttributes);            
-         }         
-         place.setServiceLevel(defaultServiceLevel);
+         }
+         place.setServiceLevel(ServiceLevel.fromString(defaultServiceLevelStr));
          place.setAccount(account.getId());
          place.setPrimary(true);
          place = placeDao.create(place);

--- a/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/platform/handlers/CreateAccountHandler.java
@@ -61,9 +61,12 @@ import com.iris.messages.service.AccountService.CreateAccountRequest;
 import com.iris.platform.location.TimezonesChangeHelper;
 import com.iris.platform.location.TimezonesManager;
 import com.iris.security.authz.AuthorizationGrant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class CreateAccountHandler implements ContextualRequestMessageHandler<Account> {
+   private static final Logger logger = LoggerFactory.getLogger(CreateAccountHandler.class);
 
    public static final String EMAIL_IN_USE_ERROR_CODE = "error.signup.emailinuse";
    public static final String EMAIL_IN_USE_ERROR_MSG = "This email address is already in use. Please Sign In.";
@@ -129,7 +132,8 @@ public class CreateAccountHandler implements ContextualRequestMessageHandler<Acc
       this.placeTransformer = placeTransformer;
       this.bus = bus;
       this.timezoneHelper = new TimezonesChangeHelper(timezonesMgr);
-      this.defaultServiceLevel= ServiceLevel.fromString(defaultServiceLevelStr);
+      this.defaultServiceLevel = ServiceLevel.fromString(defaultServiceLevelStr);
+      logger.info("Using {} as default service level", defaultServiceLevelStr);
    }
 
    @Override


### PR DESCRIPTION
Allow the default service level to be configured, ideally there would be a way to validate this on startup rather than failing at runtime if misconfigured, but that doesn't seem to be trivially possible at the moment.