### PR TITLE
Automate release for khakis and platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ cache:
   directories:
   - $HOME/.gradle
 script: ./gradlew test
+
+deploy:
+  - provider: script
+    script: bash khakis/bin/release.sh
+    on:
+      branch: automate-build 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ script: ./gradlew test
 deploy:
   - provider: script
     script: bash khakis/bin/release.sh
+    skip_cleanup: true
     on:
       branch: automate-build 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ deploy:
   - provider: script
     script: bash khakis/bin/release.sh
     skip_cleanup: true
-    on:
-      branch: automate-build 
+    on.tags: true

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -22,7 +22,6 @@ dependencies {
    classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5"
    classpath "com.netflix.nebula:gradle-contacts-plugin:3.0.1"
    classpath 'se.transmode.gradle:gradle-docker:1.2'
-   classpath "org.ajoberstar:grgit:1.7.0"
+   classpath "org.ajoberstar.grgit:grgit-gradle:4.0.0-rc.1"
    classpath "org.owasp:dependency-check-gradle:5.2.2"
-
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,3 +1,7 @@
+apply plugin: 'org.ajoberstar.grgit'
+
+ext.repo = grgit.open()
+
 ext.buildTime = new Date ()
 def writeVersion(major, minor, patch, qualifier) {
    def versionFile = file("version.properties")

--- a/khakis/bin/common.sh
+++ b/khakis/bin/common.sh
@@ -7,9 +7,12 @@ docker_build() {
     local DOCKER_PATH="$1"
     local DOCKER_NAME="${2:-$(basename ${DOCKER_PATH})}"
     local DOCKER_TAG=$(echo "${DOCKER_NAME}" |tr '-' '/')
+    if [ $DOCKER_VERSION ]; then
+        local DOCKER_VERSION=":${DOCKER_VERSION}"
+    fi
 
-    if [ -z "${bamboo_bitbucket_user}" ]; then
-        "${DOCKER_BIN}" build -t "${DOCKER_TAG}" "${DOCKER_PATH}"
+    if [ -z "${is_build_server}" ]; then
+        "${DOCKER_BIN}" build -t "${DOCKER_TAG}${DOCKER_VERSION}" "${DOCKER_PATH}"
     else
         echo "running on build server, forcing clean rebuild..."
         "${DOCKER_BIN}" build --no-cache=true -t "${DOCKER_TAG}" "${DOCKER_PATH}"

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -7,7 +7,7 @@ if [[ "${TRAVIS_REPO_SLUG}" != 'wl-net/arcusplatform' ]]; then
   exit 0  # skip due to not being on a known repo
 fi
 
-export REGISTRY_SEPERATOR='/'
+export REGISTRY_SEPERATOR='-'
 export REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
 echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -12,7 +12,7 @@ REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
 echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
 
-echo "Building and publishing containers to ${REGISTRY_SEPERATOR}"
+echo "Building and publishing containers to ${REGISTRY_NAME}"
 
 cd $ROOT/khakis
 $ROOT/khakis/bin/build.sh

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -10,6 +10,8 @@ fi
 REGISTRY_SEPERATOR='/'
 REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
+echo "$GITHUB_SECRET" | docker login -u "$GITHUB_USERNAME" --password-stdin
+
 cd $ROOT/khakis
 $ROOT/khakis/bin/build.sh
 $ROOT/khakis/bin/tag.sh

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -7,8 +7,8 @@ if [[ "${TRAVIS_REPO_SLUG}" != 'wl-net/arcusplatform' ]]; then
   exit 0  # skip due to not being on a known repo
 fi
 
-REGISTRY_SEPERATOR='/'
-REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
+export REGISTRY_SEPERATOR='/'
+export REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
 echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
 

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -10,7 +10,7 @@ fi
 REGISTRY_SEPERATOR='/'
 REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
-echo "$GITHUB_SECRET" | docker login -u "$GITHUB_USERNAME" --password-stdin
+echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
 
 cd $ROOT/khakis
 $ROOT/khakis/bin/build.sh

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -12,9 +12,13 @@ REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
 echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
 
+echo "Building and publishing containers to ${REGISTRY_SEPERATOR}"
+
 cd $ROOT/khakis
 $ROOT/khakis/bin/build.sh
+echo "tagging"
 $ROOT/khakis/bin/tag.sh
+echo "pushing"
 $ROOT/khakis/bin/push.sh
 cd -
 $GRADLE pushDocker

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -4,7 +4,7 @@ ROOT=$(git rev-parse --show-toplevel)
 GRADLE=$ROOT/gradlew
 
 if [[ "${TRAVIS_REPO_SLUG}" != 'wl-net/arcusplatform' ]]; then
-
+  exit 0  # skip due to not being on a known repo
 fi
 
 REGISTRY_SEPERATOR='/'

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+ROOT=$(git rev-parse --show-toplevel)
+GRADLE=$ROOT/gradlew
+
+if [[ "${TRAVIS_REPO_SLUG}" != 'wl-net/arcusplatform' ]]; then
+
+fi
+
+REGISTRY_SEPERATOR='/'
+REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
+
+cd $ROOT/khakis
+$ROOT/khakis/bin/build.sh
+$ROOT/khakis/bin/tag.sh
+$ROOT/khakis/bin/push.sh
+cd -
+$GRADLE pushDocker
+

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -15,10 +15,10 @@ echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME"
 echo "Building and publishing containers to ${REGISTRY_NAME}"
 
 $GRADLE :khakis:distDocker
+
 echo "tagging"
 $ROOT/khakis/bin/tag.sh
 echo "pushing"
 $ROOT/khakis/bin/push.sh
-cd -
-$GRADLE pushDocker
 
+$GRADLE pushDocker

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -14,8 +14,7 @@ echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME"
 
 echo "Building and publishing containers to ${REGISTRY_NAME}"
 
-cd $ROOT/khakis
-$ROOT/khakis/bin/build.sh
+$GRADLE :khakis:distDocker
 echo "tagging"
 $ROOT/khakis/bin/tag.sh
 echo "pushing"

--- a/khakis/build.gradle
+++ b/khakis/build.gradle
@@ -6,6 +6,7 @@ ext.dockerVersion = "${version_major}.${version_minor}.${version_patch}"
 println "Building v${platformVersion} for docker: ${dockerVersion}"
 
 task distDocker(type: Exec) {
+   environment 'DOCKER_VERSION', dockerVersion
    commandLine 'bin/build.sh' 
 }
 


### PR DESCRIPTION
This pull request adds some automation around releasing new docker containers for the platform and khakis automatically from travis ci. For now, this won't actually do anything on arcus-smart-home until the repository is whitelisted in `khakis/bin/release.sh`