### PR TITLE
Switch to bouncycastle (#124)

### DIFF
--- a/agent/arcus-gateway/src/main/java/com/iris/agent/gateway/GatewayNetty.java
+++ b/agent/arcus-gateway/src/main/java/com/iris/agent/gateway/GatewayNetty.java
@@ -15,9 +15,11 @@
  */
 package com.iris.agent.gateway;
 
+import java.security.Security;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +73,9 @@ class GatewayNetty {
 
    public static SslProvider createSslProvider() {
       Supplier<String> sslProvider = ConfigService.supplier("iris.gateway.ssl.provider", String.class, "");
+
+      Security.addProvider(new BouncyCastleProvider());
+
       switch (sslProvider.get()) {
       case "":
       case "openssl":

--- a/agent/arcus-system/build.gradle
+++ b/agent/arcus-system/build.gradle
@@ -36,6 +36,8 @@ dependencies {
    compile libraries.logback
    compile libraries.junit
    compile libraries.kxml2
+   compile libraries.bouncycastle
+   compile libraries.bouncycastle_pki
 
    compile netty_handler
    compile netty_codec_http


### PR DESCRIPTION
Switch the agent to using bouncycastle for reading PKCS#1 private key to PrivateKey object, as the old method depended on internal JDK functions which are being removed in Java 9.

This addresses #124 