### PR TITLE
Upgrade netty

### DIFF
--- a/agent/gradle.properties
+++ b/agent/gradle.properties
@@ -14,3 +14,4 @@ version_prerelease=-SNAPSHOT
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 
+netty_override_version=4.0.42.Final

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ ext.libraries << [
 		cxfJaxws: "org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:3.1.6",
 		cxfJaxb: "org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:3.1.6",
 
-		asyncHTTPClient: "org.asynchttpclient:async-http-client:2.0.37",
+		asyncHTTPClient: "org.asynchttpclient:async-http-client:2.10.4",
 
 // Apache Lucene
 		luceneCore: "org.apache.lucene:lucene-core:5.4.0",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -307,7 +307,7 @@ libraries.cucumber = [ libraries.cucumber_junit, libraries.cucumber_groovy, libr
 if (project.hasProperty("netty_override_version"))
 	ext.netty_version = "${netty_override_version}"
 else
-	ext.netty_version = "4.0.42.Final"
+	ext.netty_version = "4.1.43.Final"
 if (project.hasProperty("tcnative_override_version"))
 	ext.tcnative_version = "${tcnative_override_version}"
 else

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -320,7 +320,7 @@ ext.netty_codec = "io.netty:netty-codec:${netty_version}"
 ext.netty_codec_http = "io.netty:netty-codec-http:${netty_version}"
 ext.netty_handler = "io.netty:netty-handler:${netty_version}"
 // handler proxy only exists in versions above 4.0
-if(!netty_version.startsWith("4.0"))
+if(!netty_version.startsWith("4."))
 	ext.netty_handler_proxy = "io.netty:netty-handler-proxy:${netty_version}"
 ext.netty_epoll = "io.netty:netty-transport-native-epoll:${netty_version}"
 ext.netty_epoll_linux = "io.netty:netty-transport-native-epoll:${netty_version}:linux-x86_64"
@@ -334,7 +334,7 @@ if (OperatingSystem.current().isMacOsX()) {
 } else {
 	ext.netty_tcnative_lib = netty_tcnative_linux
 }
-if(!netty_version.startsWith("4.0")) {
+if(!netty_version.startsWith("4.")) {
     ext.netty = [netty_handler, netty_codec_http, netty_epoll, netty_handler_proxy, netty_epoll_linux, javassist, netty_tcnative, netty_tcnative_lib]
 }
 else {

--- a/platform/arcus-containers/client-bridge/src/main/java/com/iris/client/bounce/AbstractBounceHandler.java
+++ b/platform/arcus-containers/client-bridge/src/main/java/com/iris/client/bounce/AbstractBounceHandler.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
+import io.netty.handler.codec.http.*;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,14 +39,7 @@ import com.iris.bridge.server.session.Session;
 import com.iris.io.json.JSON;
 
 import io.netty.channel.Channel;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders.Names;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.QueryStringDecoder;
 
 public abstract class AbstractBounceHandler extends HttpResource {
 	private static final Logger logger = LoggerFactory.getLogger(AbstractBounceHandler.class);
@@ -131,8 +125,8 @@ public abstract class AbstractBounceHandler extends HttpResource {
 	
 	protected FullHttpResponse redirect(String url) {
 		FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FOUND);
-		response.headers().add(HttpHeaders.newNameEntity(Names.LOCATION), url);
-		response.headers().add(HttpHeaders.newNameEntity(Names.CONTENT_TYPE), BridgeHeaders.CONTENT_TYPE_JSON_UTF8);
+		response.headers().add(HttpHeaderNames.LOCATION, url);
+		response.headers().add(HttpHeaderNames.CONTENT_TYPE, BridgeHeaders.CONTENT_TYPE_JSON_UTF8);
 		response.content().writeBytes(JSON.toJson(ImmutableMap.of(ATTR_LOCATION, url)).getBytes(Charsets.UTF_8));
 		return response;
 	}

--- a/platform/arcus-containers/ipcd-bridge/build.gradle
+++ b/platform/arcus-containers/ipcd-bridge/build.gradle
@@ -17,7 +17,7 @@ apply from: file("${rootDir}/gradle/subproject.gradle")
 apply from: file("${rootDir}/gradle/container.gradle")
 
 mainClassName = "com.iris.ipcd.server.IpcdServer"
-ext.ipcd_netty_version = '4.0.32.Final'
+ext.ipcd_netty_version = '4.1.43.Final'
 
 configurations.all {
    resolutionStrategy {

--- a/platform/ipcd-common/build.gradle
+++ b/platform/ipcd-common/build.gradle
@@ -22,7 +22,7 @@ ext.agentMainManifest = manifest {
    )
 }
 
-ext.ipcd_netty_version = '4.0.32.Final'
+ext.ipcd_netty_version = '4.1.43.Final'
 
 configurations.all {
    resolutionStrategy {


### PR DESCRIPTION
Upgrade netty, holding back for agent that depends on older version due to existing Uart API for ZWave/Zigbee