### PR TITLE
Use old netty for notification-services until pushy can be updated

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -241,7 +241,9 @@ ext.libraries << [
 		sendgridJava: "com.sendgrid:sendgrid-java:4.4.1",
 		sendgridJavaOld: 'com.sendgrid:sendgrid-java:2.2.0',
 		sendgridHTTP: "com.sendgrid:java-http-client:4.2.0",
-		pushy: "com.relayrides:pushy:0.4.3",
+		pushy: dependencies.create("com.relayrides:pushy:0.4.3") {
+                        exclude group: "io.netty", module: "netty-all"
+                },
 		smackCore: "org.igniterealtime.smack:smack-core:4.0.7",
 		smackTCP: "org.igniterealtime.smack:smack-tcp:4.0.7",
 		smackExt: "org.igniterealtime.smack:smack-extensions:4.0.7",
@@ -319,6 +321,7 @@ ext.netty_transport = "io.netty:netty-transport:${netty_version}"
 ext.netty_codec = "io.netty:netty-codec:${netty_version}"
 ext.netty_codec_http = "io.netty:netty-codec-http:${netty_version}"
 ext.netty_handler = "io.netty:netty-handler:${netty_version}"
+ext.netty_all = "io.netty:netty-all:${netty_version}"
 // handler proxy only exists in versions above 4.0
 if(!netty_version.startsWith("4."))
 	ext.netty_handler_proxy = "io.netty:netty-handler-proxy:${netty_version}"

--- a/platform/arcus-containers/notification-services/build.gradle
+++ b/platform/arcus-containers/notification-services/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	compile libraries.smackExt
 	compile libraries.twilio
 	compile libraries.apacheCommonsValidator
+	compile netty_all
 
 	testCompile project (':platform:arcus-test')
 	testCompile libraries.mockito

--- a/platform/arcus-containers/notification-services/gradle.properties
+++ b/platform/arcus-containers/notification-services/gradle.properties
@@ -1,0 +1,1 @@
+netty_override_version=4.0.42.Final


### PR DESCRIPTION
Fixes an issue where APNs notifications could not be delivered due to multiple netty versions in use