### PR TITLE
Set original datatypes correctly

### DIFF
--- a/platform/arcus-modelmanager/src/main/resources/changelogs/changelog-1.0.0.xml
+++ b/platform/arcus-modelmanager/src/main/resources/changelogs/changelog-1.0.0.xml
@@ -60,7 +60,7 @@
             currLocation varchar,
             currLocationTime timestamp,
             currLocationMethod varchar,
-            pin int
+            pin varchar
          )
          </cl:update>
          <cl:rollback>DROP TABLE IF EXISTS person</cl:rollback>
@@ -136,10 +136,10 @@
             protocolName    varchar,
             protocolId      varchar,
             driverName      varchar,
-            driverVersion   int,
+            driverVersion   varchar,
             driverAddress   varchar,
             protocolAddress varchar,
-            hubId           uuid
+            hubId           varchar
          )
          </cl:update>
          <cl:rollback>DROP TABLE IF EXISTS device</cl:rollback>
@@ -832,7 +832,7 @@
 			ruleExpressions     varchar,
 			ruleDisabled        boolean,
 			ruleSuspended       boolean,
-			ruleTemplate        UUID,
+			ruleTemplate        varchar,
 			ruleVariables       varchar,
 			
 			/* action-only fields */


### PR DESCRIPTION
You can't change the datatype of a previously existing column anymore in cassandra. To allow for old pre-Arcus databases to be upgraded, we preserve the original changelog but set the datatypes correctly from the start

Previous error:
```
com.datastax.driver.core.exceptions.InvalidQueryException: Cannot re-add previously dropped column 'ruletemplate' of type text, incompatible with previous type uuid

com.iris.modelmanager.engine.command.CommandExecutionException: com.datastax.driver.core.exceptions.InvalidQueryException: Cannot re-add previously dropped column 'ruletemplate' of type text, incompatible with previous type uuid
	at com.iris.modelmanager.engine.command.CQLExecutionCommand.executeCommand(CQLExecutionCommand.java:51)
	at com.iris.modelmanager.engine.command.CQLExecutionCommand.execute(CQLExecutionCommand.java:35)
	at com.iris.modelmanager.engine.command.CompositeExecutionCommand.execute(CompositeExecutionCommand.java:71)
	at com.iris.modelmanager.engine.command.CompositeExecutionCommand.execute(CompositeExecutionCommand.java:45)
	at com.iris.modelmanager.engine.command.CompositeExecutionCommand.execute(CompositeExecutionCommand.java:71)
	at com.iris.modelmanager.engine.command.CompositeExecutionCommand.execute(CompositeExecutionCommand.java:45)
	at com.iris.modelmanager.engine.command.CompositeExecutionCommand.execute(CompositeExecutionCommand.java:71)
	at com.iris.modelmanager.engine.command.CompositeExecutionCommand.execute(CompositeExecutionCommand.java:45)
	at com.iris.modelmanager.engine.ExecutionEngine.executeCommands(ExecutionEngine.java:134)
	at com.iris.modelmanager.engine.ExecutionEngine.execute(ExecutionEngine.java:106)
	at com.iris.modelmanager.ModelManager.start(ModelManager.java:42)
	at com.iris.core.IrisAbstractApplication.exec(IrisAbstractApplication.java:185)
	at com.iris.core.IrisAbstractApplication.exec(IrisAbstractApplication.java:126)
	at com.iris.modelmanager.ModelManager.main(ModelManager.java:46)
Caused by: com.datastax.driver.core.exceptions.InvalidQueryException: Cannot re-add previously dropped column 'ruletemplate' of type text, incompatible with previous type uuid
	at com.datastax.driver.core.exceptions.InvalidQueryException.copy(InvalidQueryException.java:50)
	at com.datastax.driver.core.DriverThrowables.propagateCause(DriverThrowables.java:35)
	at com.datastax.driver.core.DefaultResultSetFuture.getUninterruptibly(DefaultResultSetFuture.java:293)
	at com.datastax.driver.core.AbstractSession.execute(AbstractSession.java:58)
	at com.datastax.driver.core.AbstractSession.execute(AbstractSession.java:39)
	at com.iris.modelmanager.engine.command.CQLExecutionCommand.executeCommand(CQLExecutionCommand.java:46)
	... 13 more
```