### PR TITLE
Enable publication to dockerhub

### DIFF
--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -8,11 +8,16 @@ if [[ "${TRAVIS_REPO_SLUG}" != 'wl-net/arcusplatform' ]]; then
 fi
 
 export REGISTRY_SEPERATOR='-'
-export REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
 
-echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
+if [ -z ${DOCKERHUB_USER+x} ]; then
+  export REGISTRY_NAME=docker.pkg.github.com/$TRAVIS_REPO_SLUG
+  echo "$GITHUB_SECRET" | docker login docker.pkg.github.com -u "$GITHUB_USERNAME" --password-stdin
+else
+  export REGISTRY_NAME=$DOCKERHUB_USER
+  echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
+fi
 
-echo "Building and publishing containers to ${REGISTRY_NAME}"
+echo "Building and publishing containers to '${REGISTRY_NAME}'"
 
 $GRADLE :khakis:distDocker
 


### PR DESCRIPTION
landing before test on fork 'wl-net/arcusplatform' to keep history cross-fork consistent.