### PR TITLE
Add support for Zooz zen26

### DIFF
--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Driver for a Zooz Zen 26 In-Wall Switch
+ *
+ */
+
+driver          "ZWZoozZen26Driver"
+description     "Driver for a Zooz Zen26 In-Wall Switch"
+version         "1.0"
+protocol        "ZWAV"
+deviceTypeHint  "Switch"
+productId       "acd43a"
+vendor          "Zooz"
+model           "Zen26"
+
+matcher         'ZWAV:Manufacturer': 0x027A, 'ZWAV:ProductType': 0xa000, 'ZWAV:ProductId': 0xa001
+
+
+capabilities	DevicePower, Switch, Indicator
+
+importCapability 'zwave/GenericZWaveSwitch'
+importCapability 'zwave/GenericZWaveVersion'
+
+// set DevicePower
+// ---------------
+DevicePower.source               DevicePower.SOURCE_LINE
+DevicePower.linecapable          true
+DevicePower.backupbatterycapable false
+
+Indicator.enabled			true
+Indicator.enableSupported	false
+
+final int  POLLING_INTERVAL_SEC = 71		// Iris 1 uses 30s
+
+final byte SWITCH_ON		= 0xff
+final byte SWITCH_OFF		= 0x00
+
+final long DFLT_READBACK_DELAY = 5000		// 5 second delay before reading
+final long DEFERRED_READ_DELAY_MSEC = 5000	// wait 5 seconds after Node Info to read level
+
+// config definitions/constants
+// ----------------------------
+final byte CNFG_LED_PARAM_NO      = 0x03		// parameter number for 'LED' setting, used to switch when LED is On and Off
+final byte CNFG_LED_SIZE          = 0x01		// size of 'LED' parameter field, in bytes
+final byte CNFG_LED_NORMAL        = 0x00		// LED 'ON' when outlet is 'OFF' (default)
+final byte CNFG_LED_INVERSE       = 0x01		// LED 'ON' when outlet is 'ON'
+
+final byte CNFG_TOGGLE_PARAM_NO   = 0x04		// parameter number for 'Toggle' setting, used to invert operation if installed upside down
+final byte CNFG_TOGGLE_SIZE       = 0x01		// size of 'Toggle' parameter field, in bytes
+final byte CNFG_TOGGLE_NORMAL     = 0x00		// Top/Up is 'ON' (default)
+final byte CNFG_TOGGLE_INVERT     = 0x01		// Top/Up is 'OFF'
+
+final byte CNFG_RESET_PARAM_NO    = 0x00		// parameter number to reset configuration to factory default
+final byte CNFG_RESET_SIZE        = 0x81		// size field (actually flags indicating: 0x80 = reset, 0x01 = ignore values, use factory settings
+final byte CNFG_RESET_VALUE       = 0x00        // Not used by device
+final int  OFFLINE_TIMEOUT_SECS   = 1800 		// 30 min
+
+final String DEVICE_NAME = 'Zooz Zen 26 In-Wall Switch'
+
+
+onAdded {
+	vars.'CURRENT_NAME' = DEVICE_NAME
+	log.debug "${DEVICE_NAME} added with Attributes {}", message.attributes
+
+	// set default attribute values
+	DevicePower.source                  DevicePower.SOURCE_LINE
+	DevicePower.linecapable             true
+	DevicePower.backupbatterycapable    false
+	DevicePower.sourcechanged           ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+
+	Switch.state                        Switch.STATE_OFF
+	Switch.statechanged                 ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+	Switch.inverted                     false
+
+	Indicator.enabled                   true
+	Indicator.enableSupported           false		// user cannot change the Indicator.enabled attribute for this device
+	Indicator.indicator                 Indicator.INDICATOR_ON
+	Indicator.inverted                  false
+
+	// reset the device configuration to factory defaults
+	ZWave.configuration.set(CNFG_RESET_PARAM_NO, CNFG_RESET_SIZE, CNFG_RESET_VALUE)
+}
+
+onConnected {
+	log.debug "${DEVICE_NAME} connected"
+
+	vars.'MAX_READBACKS' = 10				// used by GenericZWaveSwitch to limit maximum read operations
+	vars.'DFLT_READBACK_DELAY' = 1000		// used by GenericZWaveSwitch to determine delay between read retries (in mSec)
+	// get the current switch level
+	ZWave.switch_multilevel.get()
+
+	// These devices do NOT send a switch_multilevel.report when their level is changed locally,
+	// so periodically poll for the current switch level.  They do send a Node Info when the
+	// level is changed locally, but we also periodically poll in case we miss that message.
+	ZWave.poll(POLLING_INTERVAL_SEC, ZWave.switch_multilevel.get)
+
+	// get configuration settings
+	ZWave.configuration.get(CNFG_LED_PARAM_NO)
+	ZWave.configuration.get(CNFG_TOGGLE_PARAM_NO)
+	ZWave.setOfflineTimeout(OFFLINE_TIMEOUT_SECS)
+}
+
+
+onDisconnected {
+	log.debug "${DEVICE_NAME} disconnected"
+}
+
+
+onRemoved {
+	log.debug "${DEVICE_NAME} removed"
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Capability Support
+////////////////////////////////////////////////////////////////////////////////
+
+setAttributes(){
+	GenericZWaveSwitch.handleSetAttributes(this, DEVICE_NAME, message)
+
+	def attributes = message.attributes
+	for(attribute in attributes) {
+		switch(attribute.key) {
+			case Switch.inverted:
+				// only accept this if the Switch.inverted attribute is not null, indicating that it can be set
+				if (null != Switch.inverted.get()) {
+					// set the Switch Orientation configuration
+					ZWave.configuration.set(CNFG_TOGGLE_PARAM_NO, CNFG_TOGGLE_SIZE, attribute.value ? CNFG_TOGGLE_INVERT : CNFG_TOGGLE_NORMAL)
+					// get the current Switch Orientation configuration from the device (to verify the config was set)
+					ZWave.configuration.get(CNFG_TOGGLE_PARAM_NO)
+				} else {
+					log.warn "Attempted to set Switch.inverted attribute on device that does not support it"
+				}
+				break
+
+			case Indicator.inverted:
+				// set the LED configuration
+				ZWave.configuration.set(CNFG_LED_PARAM_NO, CNFG_LED_SIZE, attribute.value ? CNFG_LED_INVERSE : CNFG_LED_NORMAL)
+				// get the current LED configuration from the device (to verify the config was set)
+				ZWave.configuration.get(CNFG_LED_PARAM_NO)
+				break
+
+			case Indicator.enabled:
+				// The indicator cannot be enabled/disabled, only inverted
+				log.warn "Switch does not support enable/disable of Indicator"
+				Indicator.enabled true
+				break
+
+			default:
+				break
+		}
+	}
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Protocol Message Callbacks
+////////////////////////////////////////////////////////////////////////////////
+
+onZWaveMessage.switch_multilevel.report {
+	 GenericZWaveSwitch.handleMultilevelReport(this, DEVICE_NAME, message)
+
+	// adjust Indicator attributes based on reported state
+	def boolean indicatorMatchesSwitch = Indicator.inverted.get()	// LED Indicator matches switch power if inverted
+	if (Switch.STATE_OFF == Switch.state.get()) {
+		//log.debug "Set Indicator based on Inverted:$indicatorMatchesSwitch to " + (indicatorMatchesSwitch ? Indicator.INDICATOR_OFF : Indicator.INDICATOR_ON)
+		Indicator.indicator (indicatorMatchesSwitch ? Indicator.INDICATOR_OFF : Indicator.INDICATOR_ON)
+	} else {
+		//log.debug "Set Indicator based on Inverted:$indicatorMatchesSwitch to " + (indicatorMatchesSwitch ? Indicator.INDICATOR_ON : Indicator.INDICATOR_OFF)
+		Indicator.indicator (indicatorMatchesSwitch ? Indicator.INDICATOR_ON : Indicator.INDICATOR_OFF)
+	}
+}
+
+
+
+onZWaveMessage.configuration.report {
+	log.debug "${DEVICE_NAME} reported configuration: {}", message
+	byte param = message.command.get('param')
+	byte level = message.command.get('level')
+	byte val1 = message.command.get('val1')
+	log.debug "param: {}, level: {}, val1: {}", param, level, val1
+
+	if (CNFG_LED_PARAM_NO == param) {
+		log.debug "LED Inverted: {}", val1
+		if (0 == val1) {
+			// set/save the inverted attribute of the LED indicator
+			Indicator.inverted false
+			// update the indicator attribute to match (or inverse of) the current state attribute
+			Indicator.indicator ( (Switch.STATE_ON == Switch.state.get()) ? Indicator.INDICATOR_OFF : Indicator.INDICATOR_ON )
+		} else {
+			// set/save the inverted attribute of the LED indicator
+			Indicator.inverted true
+			// update the indicator attribute to match (or inverse of) the current state attribute
+			Indicator.indicator ( (Switch.STATE_ON == Switch.state.get()) ? Indicator.INDICATOR_ON : Indicator.INDICATOR_OFF )
+		}
+	}
+
+	if (CNFG_TOGGLE_PARAM_NO == param) {
+		log.debug "Toggle Switch Inverted: {}", val1
+		// set/save the inverted attribute of the switch
+		Switch.inverted ((0 == val1) ? false : true)
+	}
+}
+
+
+onZWaveNodeInfo {
+	log.debug "${DEVICE_NAME} reported Node Info: {}, {}, {}, {}, {}", message.getNodeId(), message.getStatus(), message.getBasic(), message.getGeneric(), message.getSpecific()
+	GenericZWaveSwitch.scheduleDeferredReadLevel(this, DEFERRED_READ_DELAY_MSEC)
+}
+
+
+onZWaveMessage {
+    log.debug "${DEVICE_NAME} received unhandled ZWave message {}", message
+    return false;
+}
+
+// ZEN27 reports local changes via basic report
+onZWaveMessage.basic.report {
+    byte currState = message.command.get('value')
+    log.trace "Basic Report: {}", currState
+    GenericZWaveSwitch.updateDeviceAttributes(this, DEVICE_NAME, currState)
+}

--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
@@ -23,7 +23,7 @@ description     "Driver for a Zooz Zen26 In-Wall Switch"
 version         "1.0"
 protocol        "ZWAV"
 deviceTypeHint  "Switch"
-productId       "acd43a"
+productId       "acd43b"
 vendor          "Zooz"
 model           "Zen26"
 

--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
@@ -122,7 +122,7 @@ onRemoved {
 // Capability Support
 ////////////////////////////////////////////////////////////////////////////////
 
-setAttributes(){
+setAttributes('swit') {
 	GenericZWaveSwitch.handleSwitchState(this, DEVICE_NAME, message)
 
 	def attributes = message.attributes
@@ -139,7 +139,16 @@ setAttributes(){
 					log.warn "Attempted to set Switch.inverted attribute on device that does not support it"
 				}
 				break
+			default:
+				break
+		}
+	}
+}
 
+setAttributes('indicator') {
+	def attributes = message.attributes
+	for(attribute in attributes) {
+		switch(attribute.key) {
 			case Indicator.inverted:
 				// set the LED configuration
 				ZWave.configuration.set(CNFG_LED_PARAM_NO, CNFG_LED_SIZE, attribute.value ? CNFG_LED_INVERSE : CNFG_LED_NORMAL)
@@ -158,7 +167,6 @@ setAttributes(){
 		}
 	}
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Protocol Message Callbacks

--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
@@ -100,13 +100,6 @@ onConnected {
 
 	vars.'MAX_READBACKS' = 10				// used by GenericZWaveSwitch to limit maximum read operations
 	vars.'DFLT_READBACK_DELAY' = 1000		// used by GenericZWaveSwitch to determine delay between read retries (in mSec)
-	// get the current switch level
-	ZWave.switch_multilevel.get()
-
-	// These devices do NOT send a switch_multilevel.report when their level is changed locally,
-	// so periodically poll for the current switch level.  They do send a Node Info when the
-	// level is changed locally, but we also periodically poll in case we miss that message.
-	ZWave.poll(POLLING_INTERVAL_SEC, ZWave.switch_multilevel.get)
 
 	// get configuration settings
 	ZWave.configuration.get(CNFG_LED_PARAM_NO)

--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Zooz_Zen26.driver
@@ -130,7 +130,7 @@ onRemoved {
 ////////////////////////////////////////////////////////////////////////////////
 
 setAttributes(){
-	GenericZWaveSwitch.handleSetAttributes(this, DEVICE_NAME, message)
+	GenericZWaveSwitch.handleSwitchState(this, DEVICE_NAME, message)
 
 	def attributes = message.attributes
 	for(attribute in attributes) {
@@ -171,21 +171,9 @@ setAttributes(){
 // Protocol Message Callbacks
 ////////////////////////////////////////////////////////////////////////////////
 
-onZWaveMessage.switch_multilevel.report {
-	 GenericZWaveSwitch.handleMultilevelReport(this, DEVICE_NAME, message)
-
-	// adjust Indicator attributes based on reported state
-	def boolean indicatorMatchesSwitch = Indicator.inverted.get()	// LED Indicator matches switch power if inverted
-	if (Switch.STATE_OFF == Switch.state.get()) {
-		//log.debug "Set Indicator based on Inverted:$indicatorMatchesSwitch to " + (indicatorMatchesSwitch ? Indicator.INDICATOR_OFF : Indicator.INDICATOR_ON)
-		Indicator.indicator (indicatorMatchesSwitch ? Indicator.INDICATOR_OFF : Indicator.INDICATOR_ON)
-	} else {
-		//log.debug "Set Indicator based on Inverted:$indicatorMatchesSwitch to " + (indicatorMatchesSwitch ? Indicator.INDICATOR_ON : Indicator.INDICATOR_OFF)
-		Indicator.indicator (indicatorMatchesSwitch ? Indicator.INDICATOR_ON : Indicator.INDICATOR_OFF)
-	}
+onZWaveMessage.switch_binary.report {
+	GenericZWaveSwitch.handleBinarySwitchReport(this,DEVICE_NAME,message)
 }
-
-
 
 onZWaveMessage.configuration.report {
 	log.debug "${DEVICE_NAME} reported configuration: {}", message
@@ -228,9 +216,9 @@ onZWaveMessage {
     return false;
 }
 
-// ZEN27 reports local changes via basic report
+// ZEN26 reports local changes via basic report
 onZWaveMessage.basic.report {
     byte currState = message.command.get('value')
     log.trace "Basic Report: {}", currState
-    GenericZWaveSwitch.updateDeviceAttributes(this, DEVICE_NAME, currState)
+    GenericZWaveSwitch.handleSwitchState(this, DEVICE_NAME, currState)
 }

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -4065,7 +4065,7 @@
       </pair>
       <removal>
         <step0 type="text" img="" text="TIP: Do not use other Iris devices at this time to avoid removing them. It is best if the device is within 10 feet of the hub."/>
-        <step1 type="text" img="" text="Pres the down button three times quickly."/>
+        <step1 type="text" img="" text="Press the down button three times quickly."/>
         <step2 type="text" img="" text="The LED will flash rapidly and the hub will beep when the device is successfully removed."/>
       </removal>
       <populations>
@@ -4083,7 +4083,7 @@
       </pair>
       <removal>
         <step0 type="text" img="" text="TIP: Do not use other Iris devices at this time to avoid removing them. It is best if the device is within 10 feet of the hub."/>
-        <step1 type="text" img="" text="Pres the down button three times quickly."/>
+        <step1 type="text" img="" text="Press the down button three times quickly."/>
         <step2 type="text" img="" text="The LED will flash rapidly and the hub will beep when the device is successfully removed."/>
       </removal>
       <populations>

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -4074,6 +4074,24 @@
         <population name="beta"/>
       </populations>
     </product>
+    <product id="acd43b" name="S2 Switch (Zen26)" shortname="Switch" screen="Switch" description="" manufacturer="Zooz" vendor="Zooz" cert="none" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" batteryprimsize="" batteryprimnum="0" keywords="zooz, switch, zwave, zen26" ota="No" protofamily="Z-Wave" added="2019-12-08T17:10:30-0700" lastchanged="2019-12-08T17:10:30-0700">
+      <categories>
+        <category name="Lights &amp; Switches"/>
+      </categories>
+      <pair>
+        <step1 type="text" img="" text="Press the up button three times quickly. The LED will blink rapidly in pairing mode and the hub will beep when pairing is complete"/>
+      </pair>
+      <removal>
+        <step0 type="text" img="" text="TIP: Do not use other Iris devices at this time to avoid removing them. It is best if the device is within 10 feet of the hub."/>
+        <step1 type="text" img="" text="Pres the down button three times quickly."/>
+        <step2 type="text" img="" text="The LED will flash rapidly and the hub will beep when the device is successfully removed."/>
+      </removal>
+      <populations>
+        <population name="general"/>
+        <population name="qa"/>
+        <population name="beta"/>
+      </populations>
+    </product>
     <product id="d4e156" name="Water Leak Sensor" shortname="Water Leak Sensor" screen="Water Leak" description="" manufacturer="Dome" vendor="Dome" cert="none" canbrowse="false" cansearch="false" helpurl="" pairvideourl="" batteryprimsize="CR14250" batteryprimnum="1" keywords="dome, safety, moisture, water, leak, sensor" ota="No" protofamily="Z-Wave" added="2017-04-24T07:50:30-0400" lastchanged="2018-03-08T10:27:00-0600">
       <categories>
         <category name="Water"/>


### PR DESCRIPTION
Add initial support for the Zooz Zen26 S2 Switch. Configuration options will require some follow-up to get working, but otherwise this does the basic things.