### PR TITLE
Improve kafka for clustering

### DIFF
--- a/khakis/arcus-kafka/Dockerfile
+++ b/khakis/arcus-kafka/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Environment variables for configuration
-ENV KAFKA_SCALA_VERSION 2.11
+ENV KAFKA_SCALA_VERSION 2.12
 ENV KAFKA_VERSION 2.4.0
 
 # Download and install the required version of Apache Kafka. 

--- a/khakis/arcus-kafka/kafka-cmd
+++ b/khakis/arcus-kafka/kafka-cmd
@@ -43,6 +43,10 @@ kafka_init() {
     local BID=$(cat /data/brokerid 2>/dev/null)
     [ -z "${BID}" ] && BID=1
 
+    if [[ -n "${KAFKA_BROKER_ID}" ]] ; then
+        BID="${KAFKA_BROKER_ID}"
+    fi
+
     echo "Setting up broker: brokerid=${BID}, hostname=${HSTN}, zookeeper=${ZKN} ..."
     sed -i "s/^\s*broker.id\s*=.*$/broker.id=$BID/" $KAFKA_HOME/config/server.properties
     sed -i "s/^\s*zookeeper.connect\s*=.*$/zookeeper.connect=$ZKN/" $KAFKA_HOME/config/server.properties

--- a/khakis/arcus-kafka/kafka-cmd
+++ b/khakis/arcus-kafka/kafka-cmd
@@ -29,12 +29,6 @@ kafka_docker_entry() {
 ################################################################################
 
 kafka_init() {
-    # Get the current broker ID. If the ID is zero then this server is not setup.
-    local BID=$(cat ${KAFKA_HOME}/config/server.properties  |grep broker.id |sed 's/broker.id\s*=\s*\([0-9]*\)/\1/')
-    if [ "${BID}" != "0" ]; then
-        return
-    fi
-
     echo "Initializing Apache Kafka Server..."
 
     local HSTN=$(cat /data/hostname 2>/dev/null)


### PR DESCRIPTION
* Bump scala version to 2.12 as 2.11 appears to be being phased out
* Always run setup, instead of requiring configuration file to be modified first.
* Allow broker id to be configured manually through environment variable