### PR TITLE
Allow metric reporter to be disabled

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/core/metricsreporter/config/IrisMetricsReporterConfig.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/metricsreporter/config/IrisMetricsReporterConfig.java
@@ -25,6 +25,10 @@ import com.google.inject.name.Named;
 @Singleton
 public class IrisMetricsReporterConfig {
     @Inject(optional = true)
+    @Named("metrics.topic.enabled")
+    protected boolean enabled = true;
+
+    @Inject(optional = true)
     @Named("metrics.topic.rateunit")
     protected TimeUnit topicRateUnit = TimeUnit.SECONDS;
 
@@ -52,6 +56,14 @@ public class IrisMetricsReporterConfig {
     @Inject(optional = true)
     @Named("metrics.topic.batchsize")
     protected int batchSize = 1000;
+
+    public boolean getEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     public TimeUnit getReportingUnitType() {
         return reportingUnitType;

--- a/platform/arcus-lib/src/main/java/com/iris/core/metricsreporter/reporter/IrisMetricsTopicReporter.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/metricsreporter/reporter/IrisMetricsTopicReporter.java
@@ -70,7 +70,8 @@ public class IrisMetricsTopicReporter {
    private final MetricRegistry registry;
    private final MetricFilter filter;
    private final ScheduledExecutorService executor;
-   
+
+   private final boolean reporting;
    private final String kafkaTopic;
    private final int counterBatchSize;
    private final long reportingIntervalMs;
@@ -90,7 +91,8 @@ public class IrisMetricsTopicReporter {
       this.kafkaProducer = new KafkaProducer<String, String>(config.toNuProducerProperties(), new StringSerializer(), new StringSerializer());
       this.executor = ThreadPoolBuilder.newSingleThreadedScheduler("metrics-" + config.getTopicMetrics() + "-reporter");
       this.kafkaTopic = config.getTopicMetrics();
-      
+
+      this.reporting = reporterConfig.getEnabled();
       this.filter = reporterConfig.getTopicFilter();
       this.reportingIntervalMs = TimeUnit.MILLISECONDS.convert(reporterConfig.getReportingUnit(), reporterConfig.getReportingUnitType());
       this.counterBatchSize = reporterConfig.getBatchSize();
@@ -105,7 +107,9 @@ public class IrisMetricsTopicReporter {
       if(startDelayMs < 0) {
          startDelayMs += reportingIntervalMs;
       }
-      executor.scheduleAtFixedRate(() -> report(), startDelayMs, reportingIntervalMs, TimeUnit.MILLISECONDS); 
+      if (reporting) {
+         executor.scheduleAtFixedRate(() -> report(), startDelayMs, reportingIntervalMs, TimeUnit.MILLISECONDS);
+      }
    }
    
    @PreDestroy


### PR DESCRIPTION
Allow the metric reporter to be disabled, as arcus-k8 now relies on prometheus for metric collection, rather than the old metric reporter that IRIS used.