### PR TITLE
Allow kafka replicator class to be configured

### DIFF
--- a/khakis/arcus-kafka/kafka-cmd
+++ b/khakis/arcus-kafka/kafka-cmd
@@ -60,7 +60,7 @@ kafka_init() {
     fi
 
     if [[ -n ${LISTENERS} ]] ; then
-	# e.g. PLAINTEXT://localhost:9092 for Istio
+	      # e.g. PLAINTEXT://localhost:9092 for Istio
         echo "listeners=${LISTENERS}" >> $KAFKA_HOME/config/server.properties
     fi
 

--- a/khakis/arcus-kafka/kafka-cmd
+++ b/khakis/arcus-kafka/kafka-cmd
@@ -96,6 +96,10 @@ kafka_init() {
         echo "delete.topic.enable=${KAFKA_DELETE_TOPIC_ENABLE}" >> $KAFKA_HOME/config/server.properties
     fi 
 
+    if [[ -n ${KAFKA_REPLICATOR_SELECTOR_CLASS} ]] ; then
+        echo "replica.selector.class=${KAFKA_REPLICATOR_SELECTOR_CLASS}" >> $KAFKA_HOME/config/server.properties
+    fi
+
     # Setup the data directories
     local KDD=""
     for datadir in ${KAFKA_DATA_DIRS}; do


### PR DESCRIPTION
This allows an administrator to enable kafka follower-fetching, to cut down on xDC traffic