### PR TITLE
Improve error handling

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/core/IrisAbstractApplication.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/IrisAbstractApplication.java
@@ -183,7 +183,7 @@ public abstract class IrisAbstractApplication {
             );
 
             if (app.getApplicationName().equals(IrisApplicationModule.DEFAULT_APPLICATION_NAME)) {
-               logger.error("Application cannot start without a name.");
+               logger.error("Application cannot start without a name");
                System.exit(1);
             }
             StartupListener.publishStarted();

--- a/platform/arcus-lib/src/main/java/com/iris/core/IrisAbstractApplication.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/IrisAbstractApplication.java
@@ -181,6 +181,11 @@ public abstract class IrisAbstractApplication {
                   app.getApplicationVersion(),
                   app.getApplicationDir()
             );
+
+            if (app.getApplicationName().equals(IrisApplicationModule.DEFAULT_APPLICATION_NAME)) {
+               logger.error("Application cannot start without a name.");
+               System.exit(1);
+            }
             StartupListener.publishStarted();
             app.start();
          }

--- a/platform/arcus-lib/src/main/java/com/iris/core/IrisApplicationModule.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/IrisApplicationModule.java
@@ -49,10 +49,12 @@ public class IrisApplicationModule implements BootstrapModule {
    
    private static final Logger logger = LoggerFactory.getLogger(IrisApplicationModule.class);
 
-   private String applicationName = "<unknown>";
+   public final static String DEFAULT_APPLICATION_NAME = "<unknown>";
+
+   private String applicationName = DEFAULT_APPLICATION_NAME;
    private String applicationVersion = "<unknown>";
    private String applicationDir = "";
-   
+
    @PostConstruct
    public void init() {
       try {

--- a/platform/arcus-lib/src/main/java/com/iris/core/IrisApplicationModule.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/IrisApplicationModule.java
@@ -62,7 +62,7 @@ public class IrisApplicationModule implements BootstrapModule {
             urls.add(en.nextElement());
          }
          if(urls.isEmpty()) {
-            logger.info("No application.properties was found");
+            logger.warn("No application.properties was found");
             return;
          }
          


### PR DESCRIPTION
Improve error handling when application name is not provided (e.g. when the application.properties file is missing) - Resolves #187.