### PR TITLE
Add test timeout on TestAES

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -219,7 +219,7 @@ ext.libraries << [
 		powermock_easymock: "org.powermock:powermock-api-easymock:1.7.3",
 
 //Junit
-		junit: "junit:junit:4.11",
+		junit: "junit:junit:4.13",
 
 // Apache Shiro
 		shiro: "org.apache.shiro:shiro-core:1.3.2",

--- a/platform/arcus-security/src/test/java/com/iris/security/crypto/TestAES.java
+++ b/platform/arcus-security/src/test/java/com/iris/security/crypto/TestAES.java
@@ -6,11 +6,15 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 
 import java.security.Security;
 
 public class TestAES {
     private AES aes;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10); // 10 seconds max per method tested
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
TestAES can hang when there is little entropy available. Set a timeout on TestAES so that this behavior can be identified quickly, rather than waiting for the entire build to timeout.