### PR TITLE
Explicitly use directExecutor and Futures.transformAsync

### DIFF
--- a/common/arcus-common/src/main/java/com/iris/util/Results.java
+++ b/common/arcus-common/src/main/java/com/iris/util/Results.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
 /**
  *
@@ -51,7 +52,7 @@ public class Results {
          public void onFailure(Throwable t) {
 	         callback.onResult((Result<T>)Results.fromError(t));
          }
-		});
+		}, MoreExecutors.directExecutor());
 	}
 
 	private static abstract class AbstractResult<T> implements Result<T> {

--- a/common/arcus-metrics/src/main/java/com/iris/metrics/AsyncTimer.java
+++ b/common/arcus-metrics/src/main/java/com/iris/metrics/AsyncTimer.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Timer;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
 /**
  * Doesn't implement {@link Metric} to make it clear that it's really a lightweight composite of two {@link Timer}s that
@@ -86,7 +87,7 @@ public class AsyncTimer
             }
          };
 
-         Futures.addCallback(operation, callback);
+         Futures.addCallback(operation, callback, MoreExecutors.directExecutor());
 
          return operation;
       }

--- a/platform/arcus-containers/alexa-bridge/src/main/java/com/iris/alexa/shs/handlers/v2/HealthCheckDirectiveHandler.java
+++ b/platform/arcus-containers/alexa-bridge/src/main/java/com/iris/alexa/shs/handlers/v2/HealthCheckDirectiveHandler.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.iris.alexa.AlexaUtil;
@@ -70,7 +71,7 @@ public class HealthCheckDirectiveHandler {
                logger.error("alexa health check failed: ", t);
                future.set(badHealth());
             }
-         });
+         }, MoreExecutors.directExecutor());
       } catch(Exception e) {
          logger.error("alexa health check failed: ", e);
          future.set(badHealth());
@@ -93,7 +94,7 @@ public class HealthCheckDirectiveHandler {
          response.setHealthy(true);
          response.setDescription("The system is currently healthy");
          return response;
-      });
+      }, MoreExecutors.directExecutor());
    }
 
    private HealthCheckResponse badHealth() {

--- a/platform/arcus-containers/alexa-bridge/src/main/java/com/iris/alexa/shs/handlers/v2/SmartHomeSkillV2Handler.java
+++ b/platform/arcus-containers/alexa-bridge/src/main/java/com/iris/alexa/shs/handlers/v2/SmartHomeSkillV2Handler.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,7 +124,8 @@ public class SmartHomeSkillV2Handler implements SmartHomeSkillHandler {
                Preconditions.checkNotNull(input, "input cannot be null");
                Header h = Header.v2(message.getHeader().getMessageId(), input.getName(), input.getNamespace());
                return new AlexaMessage(h, input);
-            }
+            },
+            MoreExecutors.directExecutor()
          );
       }
 
@@ -133,7 +135,7 @@ public class SmartHomeSkillV2Handler implements SmartHomeSkillHandler {
          Txfm txfm = Txfm.transformerFor(message);
          PlatformMessage platformMessage = txfm.txfmRequest(message, placeId, populationCacheMgr.getPopulationByPlaceId(placeId), (int) config.getRequestTimeoutMs());
          logger.debug("[{}] transformed to platform message [{}]", message, platformMessage);
-         return Futures.transform(
+         return Futures.transformAsync(
             busClient.request(platformMessage),
             (AsyncFunction<PlatformMessage, AlexaMessage>) input -> {
                metrics.timeServiceSuccess(platformMessage.getMessageType(), startTime);

--- a/platform/arcus-containers/alexa-bridge/src/main/java/com/iris/alexa/shs/handlers/v3/SmartHomeSkillV3Handler.java
+++ b/platform/arcus-containers/alexa-bridge/src/main/java/com/iris/alexa/shs/handlers/v3/SmartHomeSkillV3Handler.java
@@ -87,7 +87,7 @@ public class SmartHomeSkillV3Handler implements SmartHomeSkillHandler {
       Txfm txfm = Txfm.transformerFor(message);
       PlatformMessage platformMessage = txfm.txfmRequest(message, placeId, populationCacheMgr.getPopulationByPlaceId(placeId), (int) config.getRequestTimeoutMs());
       logger.debug("[{}] transformed to platform message [{}]", message, platformMessage);
-      return Futures.transform(
+      return Futures.transformAsync(
          busClient.request(platformMessage),
          (AsyncFunction<PlatformMessage, AlexaMessage>) input -> {
             metrics.timeServiceSuccess(platformMessage.getMessageType(), startTime);

--- a/platform/arcus-containers/subsystem-service/src/main/java/com/iris/platform/subsystem/incident/BaseAlarmIncidentService.java
+++ b/platform/arcus-containers/subsystem-service/src/main/java/com/iris/platform/subsystem/incident/BaseAlarmIncidentService.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -387,7 +388,8 @@ public abstract class BaseAlarmIncidentService implements AlarmIncidentService {
 						/* no op */
 						logger.debug("Failed to cancel incident [{}]", incidentAddress, t);
 					}
-				}
+				},
+				MoreExecutors.directExecutor()
 			);
 		}
 		return toModel( incident );

--- a/platform/arcus-lib/src/main/java/com/iris/capability/builder/ReflectiveCommandHandler.java
+++ b/platform/arcus-lib/src/main/java/com/iris/capability/builder/ReflectiveCommandHandler.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,7 +148,7 @@ class ReflectiveCommandHandler implements ContextualEventHandler<MessageBody> {
 	}
 
 	private static ListenableFuture<MessageBody> translateFromAsync(Object future, com.google.common.base.Function<Object, MessageBody> translator) {
-		return Futures.transform((ListenableFuture<Object>) future, translator);
+		return Futures.transform((ListenableFuture<Object>) future, translator, MoreExecutors.directExecutor());
 	}
 
 	private final Method method;
@@ -195,7 +196,8 @@ class ReflectiveCommandHandler implements ContextualEventHandler<MessageBody> {
                      context.respondToPlatform(event);
                   }
 
-               }
+               },
+			   MoreExecutors.directExecutor()
          );
       }
       catch(InvocationTargetException e) {

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/BaseCassandraCRUDDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/BaseCassandraCRUDDao.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -321,7 +322,7 @@ public abstract class BaseCassandraCRUDDao<I, T extends BaseEntity<I, T>> implem
 
             ResultSetFuture entityResultSetFuture = session.executeAsync(entityQuery);
 
-            entityFutures.add(Futures.transform(entityResultSetFuture, entityTransform));
+            entityFutures.add(Futures.transform(entityResultSetFuture, entityTransform, MoreExecutors.directExecutor()));
          }
 
          return Futures

--- a/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/HubDAOImpl.java
+++ b/platform/arcus-lib/src/main/java/com/iris/core/dao/cassandra/HubDAOImpl.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.eclipse.jdt.annotation.Nullable;
@@ -495,7 +496,7 @@ public class HubDAOImpl extends BaseCassandraCRUDDao<String, Hub> implements Hub
                ctxt.stop();
                hubInsertCellBackupFailure.inc();
             }
-         });
+         }, MoreExecutors.directExecutor());
       });
    }
 
@@ -605,7 +606,7 @@ public class HubDAOImpl extends BaseCassandraCRUDDao<String, Hub> implements Hub
             ctxt.stop();
             hubUpdateAttributesFailure.inc();
          }
-      });
+      }, MoreExecutors.directExecutor());
    }
 
    @Override

--- a/platform/arcus-lib/src/main/java/com/iris/executor/PlaceExecutor.java
+++ b/platform/arcus-lib/src/main/java/com/iris/executor/PlaceExecutor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PreDestroy;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class PlaceExecutor {
 				public void onFailure(Throwable t) {
 					logger.warn("Error handling message [{}]", message, t);
 				}
-			});
+			}, MoreExecutors.directExecutor());
 		});
 	}
 	

--- a/platform/arcus-lib/src/main/java/com/iris/platform/pairing/customization/RuleTemplateRequestor.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/pairing/customization/RuleTemplateRequestor.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -76,7 +77,8 @@ public class RuleTemplateRequestor {
 		return 
 			Futures.transform(
 				requestor.request(request), 
-				(Function<PlatformMessage, List<Map<String, Object>>>) (message) -> ListRuleTemplatesResponse.getRuleTemplates(message.getValue(), ImmutableList.of())
+				(Function<PlatformMessage, List<Map<String, Object>>>) (message) -> ListRuleTemplatesResponse.getRuleTemplates(message.getValue(), ImmutableList.of()),
+				MoreExecutors.directExecutor()
 			);
 	}
 	

--- a/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraSchedulerModelDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraSchedulerModelDao.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -188,7 +189,8 @@ public class CassandraSchedulerModelDao extends BaseModelDao implements Schedule
             ResultSetFuture resultFuture = session().executeAsync( findById.bind(schedulerId) );
             ListenableFuture<ModelEntity> modelFuture = Futures.transform(
                   resultFuture,
-                  (Function<ResultSet, ModelEntity>) (result) -> toModel(result.one(), includeWeekdays)
+                  (Function<ResultSet, ModelEntity>) (result) -> toModel(result.one(), includeWeekdays),
+                  MoreExecutors.directExecutor()
             );
             modelFutures.add(modelFuture);
          }

--- a/platform/arcus-video/src/main/java/com/iris/video/cql/v2/CassandraVideoV2Dao.java
+++ b/platform/arcus-video/src/main/java/com/iris/video/cql/v2/CassandraVideoV2Dao.java
@@ -280,7 +280,7 @@ public class CassandraVideoV2Dao implements VideoDao {
 		if(metadata != null && metadata.getTags().contains(VideoConstants.TAG_FAVORITE)) {
 			BatchStatement stmt = new BatchStatement(BatchStatement.Type.LOGGED);
 			addStatementsForRemoveFromFavoriteTables(stmt, metadata);	
-			return Futures.transform(
+			return Futures.transformAsync(
 					VideoV2Util.executeAsyncAndUpdateTimer(session, stmt, RemoveTagsTimer),
 	            (AsyncFunction<ResultSet, Set<String>>) input -> {
 	            	Set<String> expectedTags = new HashSet<>(metadata.getTags());

--- a/tools/oculus/src/main/java/com/iris/oculus/modules/account/AccountController.java
+++ b/tools/oculus/src/main/java/com/iris/oculus/modules/account/AccountController.java
@@ -17,6 +17,7 @@ package com.iris.oculus.modules.account;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.iris.billing.client.RecurlyTokenClient;
 import com.iris.billing.client.model.request.BillingInfoRequest;
@@ -128,7 +129,7 @@ public class AccountController extends SessionAwareController {
          public void onFailure(Throwable t) {
             future.setError(t);
          }
-      });
+      }, MoreExecutors.directExecutor());
 
       return future;
    }
@@ -157,7 +158,7 @@ public class AccountController extends SessionAwareController {
          public void onFailure(Throwable t) {
             future.setError(t);
          }
-      });
+      }, MoreExecutors.directExecutor());
 
       return future;
    }


### PR DESCRIPTION
Explicitly use directExecutor and Futures.transformAsync instead of older deprecated APIs that provide a directExecutor internally.