### PR TITLE
Allow schedules to be recalculated in event of error (#198)

### DIFF
--- a/common/arcus-model/src/main/resources/capability/scheduler.xml
+++ b/common/arcus-model/src/main/resources/capability/scheduler.xml
@@ -101,7 +101,10 @@ If a schedule with the given id already exists with the same type this will be a
          name="Delete"
          description="Deletes this scheduler object and all associated schedules, this is generally not recommended.  If the target object is deleted, this Scheduler will automatically be deleted.">
       </c:method>
-   
+       <c:method
+         name="RecalculateCommand"
+         description="Recalculate the next time to run at">
+       </c:method>
    </c:methods>
 
    <c:events>

--- a/common/arcus-model/src/main/resources/capability/scheduler.xml
+++ b/common/arcus-model/src/main/resources/capability/scheduler.xml
@@ -102,7 +102,7 @@ If a schedule with the given id already exists with the same type this will be a
          description="Deletes this scheduler object and all associated schedules, this is generally not recommended.  If the target object is deleted, this Scheduler will automatically be deleted.">
       </c:method>
        <c:method
-         name="RecalculateCommand"
+         name="RecalculateSchedule"
          description="Recalculate the next time to run at">
        </c:method>
    </c:methods>

--- a/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformEventSchedulerService.java
+++ b/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformEventSchedulerService.java
@@ -177,6 +177,7 @@ public class PlatformEventSchedulerService implements EventSchedulerService, Par
       }
 
       if (SchedulerModel.getNextFireTime(executor.getScheduler()).getTime() < System.currentTimeMillis()) {
+         metrics.onCommandRescheduled();
          logger.warn("Found scheduler in need of update: [{}]", executor.getScheduler().getId());
          executor.onPlatformMessage(PlatformMessage
                  .builder()
@@ -478,6 +479,7 @@ public class PlatformEventSchedulerService implements EventSchedulerService, Par
       private final Counter commandFired;
       private final Counter commandExpired;
       private final Counter commandError;
+      private final Counter commandRescheduled;
       
       private SchedulerMetrics() {
          IrisMetricSet metrics = IrisMetrics.metrics("scheduler");
@@ -489,6 +491,7 @@ public class PlatformEventSchedulerService implements EventSchedulerService, Par
          this.commandFired = metrics.counter("command.sent");
          this.commandExpired = metrics.counter("command.expired");
          this.commandError = metrics.counter("command.error");
+         this.commandRescheduled = metrics.counter("command.rescheduled");
          
          metrics.gauge("partition.count",   (Supplier<Integer>) () -> partitions.size());
          metrics.gauge("partition.pending", (Supplier<Integer>) () -> activeJobs.size());
@@ -525,7 +528,10 @@ public class PlatformEventSchedulerService implements EventSchedulerService, Par
       public void onCommandError() {
          this.commandError.inc();
       }
-      
+
+      public void onCommandRescheduled() {
+         this.commandRescheduled.inc();
+      }
    }
 }
 

--- a/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformEventSchedulerService.java
+++ b/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformEventSchedulerService.java
@@ -183,7 +183,7 @@ public class PlatformEventSchedulerService implements EventSchedulerService, Par
                  .from(Address.fromString(SchedulerModel.getTarget(executor.getScheduler())))
                  .to(Address.platformService(executor.getScheduler().getId(), SchedulerCapability.NAMESPACE))
                  .withPlaceId(SchedulerModel.getPlaceId(executor.getScheduler()))
-                 .withPayload(SchedulerCapability.RecalculateCommandRequest.NAME)
+                 .withPayload(SchedulerCapability.RecalculateScheduleRequest.NAME)
                  .withPopulation(population)
                  .create());
       }

--- a/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformSchedulerCapabilityDispatcher.java
+++ b/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformSchedulerCapabilityDispatcher.java
@@ -361,9 +361,9 @@ class PlatformSchedulerCapabilityDispatcher extends BaseModelHandler implements 
             fireCommand(request);
             return SchedulerCapability.FireCommandResponse.instance();
 
-         case SchedulerCapability.RecalculateCommandRequest.NAME:
+         case SchedulerCapability.RecalculateScheduleRequest.NAME:
             handler.updated();
-            return SchedulerCapability.RecalculateCommandResponse.instance();
+            return SchedulerCapability.RecalculateScheduleResponse.instance();
          }
          
          return Errors.unsupportedMessageType(message.getMessageType());

--- a/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformSchedulerCapabilityDispatcher.java
+++ b/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformSchedulerCapabilityDispatcher.java
@@ -360,7 +360,10 @@ class PlatformSchedulerCapabilityDispatcher extends BaseModelHandler implements 
          case SchedulerCapability.FireCommandRequest.NAME:
             fireCommand(request);
             return SchedulerCapability.FireCommandResponse.instance();
-            
+
+         case SchedulerCapability.RecalculateCommandRequest.NAME:
+            handler.updated();
+            return SchedulerCapability.RecalculateCommandResponse.instance();
          }
          
          return Errors.unsupportedMessageType(message.getMessageType());
@@ -454,7 +457,7 @@ class PlatformSchedulerCapabilityDispatcher extends BaseModelHandler implements 
       
       sendRequest(body);
    }
-   
+
    private TimeOfDayCommand scheduleWeeklyCommand(MessageBody request) {
       String scheduleId = ScheduleWeeklyCommandRequest.getSchedule(request);
       Errors.assertRequiredParam(scheduleId, ScheduleWeeklyCommandRequest.ATTR_SCHEDULE);

--- a/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformSchedulerRegistry.java
+++ b/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformSchedulerRegistry.java
@@ -48,7 +48,7 @@ import com.iris.population.PlacePopulationCacheManager;
  */
 // TODO add in caching...
 @Singleton
-class PlatformSchedulerRegistry implements SchedulerRegistry {
+public class PlatformSchedulerRegistry implements SchedulerRegistry {
    private static final Logger logger = LoggerFactory.getLogger(PlatformSchedulerRegistry.class);
 
    private final SunriseSunsetCalc calculator;

--- a/platform/arcus-containers/scheduler-service/src/test/java/com/iris/platform/scheduler/TestPlatformEventSchedulerService.java
+++ b/platform/arcus-containers/scheduler-service/src/test/java/com/iris/platform/scheduler/TestPlatformEventSchedulerService.java
@@ -33,10 +33,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
-import com.google.inject.Provides;
 import com.google.inject.name.Named;
+import com.google.inject.Provides;
 import com.iris.common.scheduler.ScheduledTask;
 import com.iris.common.scheduler.Scheduler;
+import com.iris.core.dao.PlaceDAO;
 import com.iris.messages.address.Address;
 import com.iris.messages.capability.SchedulerCapability;
 import com.iris.messages.event.Listener;
@@ -47,6 +48,7 @@ import com.iris.platform.partition.PlatformPartition;
 import com.iris.platform.scheduler.model.PartitionOffset;
 import com.iris.platform.scheduler.model.ScheduledCommand;
 import com.iris.service.scheduler.PlatformEventSchedulerService;
+import com.iris.service.scheduler.PlatformSchedulerRegistry;
 import com.iris.test.IrisMockTestCase;
 import com.iris.test.Mocks;
 
@@ -54,7 +56,7 @@ import com.iris.test.Mocks;
 /**
  * 
  */
-@Mocks(value={ Scheduler.class, ScheduleDao.class })
+@Mocks(value={ Scheduler.class, ScheduleDao.class, PlaceDAO.class, PlatformSchedulerRegistry.class })
 public class TestPlatformEventSchedulerService extends IrisMockTestCase {
 
 
@@ -62,6 +64,8 @@ public class TestPlatformEventSchedulerService extends IrisMockTestCase {
    
    @Inject Scheduler mockScheduler;
    @Inject ScheduleDao mockScheduleDao;
+   @Inject PlaceDAO mockPlaceDao;
+   @Inject PlatformSchedulerRegistry mockPlatformSchedulerRegistry;
    
    @Inject PlatformEventSchedulerService service;
    

--- a/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/SchedulerConfig.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/SchedulerConfig.java
@@ -26,6 +26,7 @@ public class SchedulerConfig {
    public static final String PARAM_SCHEDULING_THREAD_POOL_SIZE  = "scheduler.schedulingThreadPoolSize";
    public static final String PARAM_DISPATCH_THREAD_POOL_SIZE    = "scheduler.dispatchThreadPoolSize";
    public static final String PARAM_DEFAULT_EXPIRATION_TIME_SEC  = "scheduler.defaultExpirationTimeSec";
+   public static final String PARAM_SCHEDULER_SANITY_CHECK       = "scheduler.sanity.check";
 
    @Inject(optional = true) @Named(PARAM_WINDOW_SIZE_SEC)
    private int windowSizeSec = 60;
@@ -37,7 +38,9 @@ public class SchedulerConfig {
    private int dispatchThreadPoolSize = 40;
    @Inject(optional = true) @Named(PARAM_DEFAULT_EXPIRATION_TIME_SEC)
    private int defaultExpirationTimeSec = (int) TimeUnit.DAYS.toSeconds(1);
-   
+   @Inject(optional = true) @Named(PARAM_SCHEDULER_SANITY_CHECK)
+   private boolean sanityCheckExisting = false;
+
    /**
     * @return the windowSizeSec
     */
@@ -107,6 +110,19 @@ public class SchedulerConfig {
    public void setDefaultExpirationTimeSec(int defaultExpirationTimeSec) {
       this.defaultExpirationTimeSec = defaultExpirationTimeSec;
    }
-   
+
+   /**
+    * @return whether to sanity check or not
+    */
+   public boolean getSanityCheckExisting() {
+      return sanityCheckExisting;
+   }
+
+   /**
+    * @param sanityCheckExisting whether to sanity check or not
+    */
+   public void setSanityCheckExisting(boolean sanityCheckExisting) {
+      this.sanityCheckExisting = sanityCheckExisting;
+   }
 }
 


### PR DESCRIPTION
This PR adds a system to automatically re-calculate the nextFireTime for schedules in the event that a condition occurs where they are scheduled for a time in the past and the offsets are skipped (see #198). It's not currently understood why this condition would occur, but if it does the option `scheduler.sanity.check` can be set to `true` to perform additional sanity checking of current schedulers.