### PR TITLE
Add ZWave Ecolink Firefighter smoke/co listener

### DIFF
--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Ecolink_Firefighter.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Ecolink_Firefighter.driver
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Driver for a Z-wave Ecolink Smoke CO Detector
+ */
+
+import static com.iris.protocol.zwave.Alarm.AlarmReportV2
+
+////////////////////////////////////////////////////////////////////////////////
+// DRIVER SETUP
+////////////////////////////////////////////////////////////////////////////////
+
+driver			"ZWEcolinkFirefighterDriver"
+description	    "Driver for an Ecolink Smoke CO Sensor"
+version		    "1.0"
+protocol		"ZWAV"
+deviceTypeHint	"Smoke/CO"
+productId		"831acf"
+vendor 		    "Uncertified"
+model 			"FF-ZWAVE5"
+
+matcher         'ZWAV:Manufacturer': 0x014A, 'ZWAV:ProductType': 0x0005, 'ZWAV:ProductId': 0x000f
+
+
+capabilities	Smoke, CarbonMonoxide
+
+
+DevicePower {
+   source DevicePower.SOURCE_BATTERY
+   linecapable false
+   backupbatterycapable false
+   bind sourcechanged to source
+}
+
+Smoke {
+   Smoke.smoke Smoke.SMOKE_SAFE
+   bind smokechanged to Smoke.smoke
+}
+
+CarbonMonoxide {
+   CarbonMonoxide.co CarbonMonoxide.CO_SAFE
+   CarbonMonoxide.eol CarbonMonoxide.EOL_OK
+   bind cochanged to CarbonMonoxide.co
+}
+
+Test {
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PLATFORM LIFECYCLE
+////////////////////////////////////////////////////////////////////////////////
+onAdded {
+   log.debug "{} added", DEVICE_NAME
+
+   Test.lastTestTime       ((null != DeviceAdvanced.added.get()) ? DeviceAdvanced.added.get() : new Date())
+}
+
+onConnected {
+   log.debug "{} connected", DEVICE_NAME
+}
+
+onDisconnected {
+   log.debug "{} disconnected", DEVICE_NAME
+}
+
+
+onRemoved {
+   log.debug "{} removed", DEVICE_NAME
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// REFLEX CONFIGURATION
+////////////////////////////////////////////////////////////////////////////////
+
+ZWave {
+    offlineTimeout 210, MINUTES
+
+    //**********************************************************************************
+    //SMOKE REFLEXES
+    //**********************************************************************************
+    match reflex {
+        on alarm.report, notificationtype: 0x01, event: 0x02
+        set Smoke.smoke, Smoke.SMOKE_DETECTED
+    }
+
+    match reflex {
+        on alarm.report, notificationtype: 0x01, event: 0x00
+        set Smoke.smoke, Smoke.SMOKE_SAFE
+    }
+
+    //**********************************************************************************
+    //CO REFLEXES
+    //**********************************************************************************
+    match reflex {
+        on alarm.report, notificationtype: 0x02, event: 0x02
+        set CarbonMonoxide.co, CarbonMonoxide.CO_DETECTED
+    }
+    match reflex {
+        on alarm.report, notificationtype: 0x02, event: 0x00
+        set CarbonMonoxide.co, CarbonMonoxide.CO_SAFE
+    }
+}
+
+onZWaveMessage.battery.report {
+   // pass message to generic ZWave Battery Report handler
+   GenericZWaveBattery.handleBatteryReport(this, DEVICE_NAME, message)
+}
+
+onZWaveMessage {
+    log.debug "{} received unhandled ZWave message {} with data {}", DEVICE_NAME, message, message.command.recvBytes
+    return false;
+}

--- a/platform/arcus-prodcat/src/main/resources/product_catalog.xml
+++ b/platform/arcus-prodcat/src/main/resources/product_catalog.xml
@@ -4288,6 +4288,29 @@
         <population name="beta"/>
       </populations>
     </product>
+    <product id="831acf" name="Firefighter (FF-ZWAVE5)" shortname="Smoke Detector" screen="Smoke/CO"  description="" manufacturer="Ecolink" vendor="Ecolink" cert="none" canbrowse="false" cansearch="false" helpurl="" pairvideourl="" batteryprimsize="CR123" batteryprimnum="1" keywords="ecolink, sensor, alarm, zwave, battery, smoke, firefighter, detector, ff-zwave5" ota="No" protofamily="Z-Wave" added="2020-04-14T21:00:00-0600" lastchanged="2020-04-14T21:00:00-0600">
+      <categories>
+        <category name="Smoke &amp; CO"/>
+      </categories>
+      <pair>
+        <step1 type="text" img="" text="Insert the batteries"/>
+        <step2 type="text" img="" text="Press teh pair button on the device for one second"/>
+      </pair>
+      <removal>
+        <step1 type="text" img="" text="The hub will beep when the device is successfully removed."/>
+      </removal>
+      <reset>
+        <step1 type="text" img="" text="Put the battery in the sensor"/>
+        <step2 type="text" img="" text="Do not press the tamper switch"/>
+        <step3 type="text" img="" text="Hold the learn button for 10 seconds until the LED turns RED"/>
+        <step4 type="text" img="" text="Release the learn button and wait for the sensor’s green LED to “breath” on and off continuously. The sensor is now ready to be added to a Z-Wave Plus network, and all settings have been restored."/>
+      </reset>
+      <populations>
+        <population name="general"/>
+        <population name="qa"/>
+        <population name="beta"/>
+      </populations>
+    </product>
     <product id="64ffad" name="Vizia Electrical Outlet (VRR15-1LZ Z-Wave)" shortname="Electrical Outlet" screen="Switch" description="" manufacturer="Leviton" vendor="Leviton" cert="workswith" canbrowse="true" cansearch="true" helpurl="" pairvideourl="" keywords="leviton, indoor, control, in, wall, outlet, plug, switch, energy, duplex, receptacle, 120, volt, power, zwave, vizia, vrr15, vrr15-1lz, decora" ota="No" protofamily="Z-Wave" added="2016-02-29T10:00:00-0600" lastchanged="2018-03-08T10:27:00-0600">
       <categories>
         <category name="Lights &amp; Switches"/>


### PR DESCRIPTION
Add a driver for the Ecolink Firefighter, see https://cdn.shopify.com/s/files/1/0218/7704/files/ecolink-z-wave-plus-fire-fighter-smoke-fire-carbon-monoxide-audio-alarm-detector.pdf?9764037641739232463

have tested smoke detector, but not CO listener