### PR TITLE
Disable arcus-kairosdb as upstream is broken

### DIFF
--- a/khakis/bin/build.sh
+++ b/khakis/bin/build.sh
@@ -13,7 +13,7 @@ if [ -z "${IMAGES}" ]; then
     IMAGES="${IMAGES} arcus-zookeeper"
     IMAGES="${IMAGES} arcus-kafka"
     IMAGES="${IMAGES} arcus-cassandra"
-    IMAGES="${IMAGES} arcus-kairosdb"
+#    IMAGES="${IMAGES} arcus-kairosdb"
 fi
 
 # Build the requested images

--- a/khakis/bin/push.sh
+++ b/khakis/bin/push.sh
@@ -13,7 +13,7 @@ if [ -z "${IMAGES}" ]; then
     IMAGES="${IMAGES} arcus-zookeeper"
     IMAGES="${IMAGES} arcus-kafka"
     IMAGES="${IMAGES} arcus-cassandra"
-    IMAGES="${IMAGES} arcus-kairosdb"
+#    IMAGES="${IMAGES} arcus-kairosdb"
 fi
 
 docker_push_to_registry() {

--- a/khakis/bin/tag.sh
+++ b/khakis/bin/tag.sh
@@ -13,7 +13,7 @@ if [ -z "${IMAGES}" ]; then
     IMAGES="${IMAGES} arcus-zookeeper"
     IMAGES="${IMAGES} arcus-kafka"
     IMAGES="${IMAGES} arcus-cassandra"
-    IMAGES="${IMAGES} arcus-kairosdb"
+#    IMAGES="${IMAGES} arcus-kairosdb"
 fi
 
 docker_tag_for_registry() {


### PR DESCRIPTION
kairosdb has been broken for a while due to https://github.com/kairosdb/kairosdb/issues/604, and while the fix has been merged, it's never been released. We don't really need kairosdb anymore though as we have prometheus available for monitoring.

Solution: disable kairosdb from building.