### PR TITLE
Increase heap size when creating topics

### DIFF
--- a/khakis/arcus-kafka/kafka-operations-provision
+++ b/khakis/arcus-kafka/kafka-operations-provision
@@ -37,7 +37,7 @@ else
    echo "Kafka is online"
 fi
 
-export KAFKA_HEAP_OPTS="-Xmx4m -Xms4m"
+export KAFKA_HEAP_OPTS="-Xmx128m -Xms4m"
 export KAFKA_JVM_PERFORMANCE_OPTS="-client -Djava.awt.headless=true"
 
 RESULT=0

--- a/khakis/arcus-kafka/kafka-provision
+++ b/khakis/arcus-kafka/kafka-provision
@@ -37,7 +37,7 @@ else
    echo "Kafka is online"
 fi
 
-export KAFKA_HEAP_OPTS="-Xmx4m -Xms4m"
+export KAFKA_HEAP_OPTS="-Xmx128m -Xms4m"
 export KAFKA_JVM_PERFORMANCE_OPTS="-client -Djava.awt.headless=true"
 
 RESULT=0	


### PR DESCRIPTION
Fixes issue where the following error is observed when creating topics:

[2020-05-02 04:49:10,806] ERROR java.lang.OutOfMemoryError: GC overhead limit exceeded
