### PR TITLE
Add ultraviolet index capability, driver support

### DIFF
--- a/common/arcus-model/src/main/resources/capability/ultravioletindex.xml
+++ b/common/arcus-model/src/main/resources/capability/ultravioletindex.xml
@@ -18,7 +18,6 @@
          optional="false" 
          min="0"
          max="12"
-         unit="lux"
          description="Reflects the current ultraviolet index measured by the device."/>
    </c:attributes>
 </c:capability>

--- a/common/arcus-model/src/main/resources/capability/ultravioletindex.xml
+++ b/common/arcus-model/src/main/resources/capability/ultravioletindex.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<c:capability
+   name="UltravioletIndex"
+   namespace="uvi"
+   enhances="Device"
+   version="1.0"
+   xmlns:c="http://www.arcussmarthome.com/schema/capability/1.0.0">
+   
+   <c:description>
+      Model of an ultraviolet index (UV index) sensor.
+   </c:description>
+   
+   <c:attributes>
+      <c:attribute 
+         name="index"
+         readwrite="r" 
+         type="int"
+         optional="false" 
+         min="0"
+         max="12"
+         unit="lux"
+         description="Reflects the current ultraviolet index measured by the device."/>
+   </c:attributes>
+</c:capability>

--- a/platform/arcus-containers/driver-services/src/main/resources/ZW_Aeotec_MultiSensor.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZW_Aeotec_MultiSensor.driver
@@ -51,7 +51,7 @@ matcher         'ZWAV:Manufacturer': 0x0086, 'ZWAV:ProductType': 0x0102, 'ZWAV:P
 matcher         'ZWAV:Manufacturer':   -122, 'ZWAV:ProductType': 0x0102, 'ZWAV:ProductId': 0x0064
 
 
-capabilities     'DevicePower', 'Temperature', 'Motion', 'Illuminance', 'RelativeHumidity', 'Tamper'
+capabilities     'DevicePower', 'Temperature', 'Motion', 'Illuminance', 'RelativeHumidity', 'Tamper', 'UltravioletIndex'
 
 importCapability 'zwave/GenericZWaveBattery'
 importCapability 'zwave/GenericZWaveVersion'
@@ -277,8 +277,9 @@ onZWaveMessage.sensor_multilevel.report {
         RelativeHumidity.humidity value
     }
 
-    if ((27 == sensorType) && (null != level)) {
-        log.debug 'ZwAeotecMultiSensor6Driver driver handle sensor multilevel report - uv: {}', level
+    if ((27 == sensorType) && (null != value)) {
+        log.debug 'ZwAeotecMultiSensor6Driver driver handle sensor multilevel report - uv: {}', value
+        UltravioletIndex.index value
     }
 }
 


### PR DESCRIPTION
Add a capability to handle ultraviolet index (uv index) and support for Aeotec MultiSensor 6 reporting of it.