### PR TITLE
Bump zookeeper to 3.5.8

### DIFF
--- a/khakis/arcus-zookeeper/Dockerfile
+++ b/khakis/arcus-zookeeper/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Environment variables for configuration
-ENV ZOOKEEPER_VERSION 3.5.7
+ENV ZOOKEEPER_VERSION 3.5.8
 
 # Download and install the required version of Apache Zookeeper.
 RUN \


### PR DESCRIPTION
3.5.7 is no longer available, so this is necessary to keep builds working