### PR TITLE
Add E21 Sengled bulb matcher

### DIFF
--- a/platform/arcus-containers/driver-services/src/main/resources/ZB_Sengled_Element_RGB_2_11.driver
+++ b/platform/arcus-containers/driver-services/src/main/resources/ZB_Sengled_Element_RGB_2_11.driver
@@ -63,6 +63,8 @@ model            "E11-N1EA"
                  // need to use a regular expression for now to get the matcher to work.
 matcher          'ZIGB:manufacturer': 0x1160, 'ZIGB:vendor': 'sengled', 'ZIGB:model': ~/^E11-N1EA[\x00]*$/
 matcher          'ZIGB:manufacturer': 0x1160, 'ZIGB:vendor': 'sengled', 'ZIGB:model': 'E11-N1EA'
+matcher          'ZIGB:manufacturer': 0x1160, 'ZIGB:vendor': 'sengled', 'ZIGB:model': ~/^E21-N1EA[\x00]*$/
+matcher          'ZIGB:manufacturer': 0x1160, 'ZIGB:vendor': 'sengled', 'ZIGB:model': 'E21-N1EA'
 
 capabilities     DeviceOta, Identify
 


### PR DESCRIPTION
Some of the newer Sengled bulbs have a new device id, but don't appear to behave any differently. Adding the device id so that Arcus recognizes it.