### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/agent/run-agent.sh
+++ b/agent/run-agent.sh
@@ -44,5 +44,4 @@ export FOURG_DISABLE=true
 # that the Sercomm or Hue device is connected to.
 export IRIS_AGENT_UPNP_IFACES=enp38s0
  
-../gradlew --no-daemon run
-
+../gradlew --daemon run


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
