### PR TITLE
Bump Gradle Max Heap Size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx1024m
 


### PR DESCRIPTION
Bump Gradle's maximum heap size to prevent the daemon from being expired due to OOM.