### PR TITLE
Fast-forward stale partition offsets to prevent scheduler OOM

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/ScheduleDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/ScheduleDao.java
@@ -44,15 +44,21 @@ public interface ScheduleDao {
          return ImmutableMap.of();
       }
       
+      Date now = new Date();
       Map<PlatformPartition, PartitionOffset> pending = new HashMap<PlatformPartition, PartitionOffset>(partitions.size());
       for(PartitionOffset offset: listPartitionOffsets()) {
          if(!partitions.contains(offset.getPartition())) {
             continue;
          }
 
-         pending.put(offset.getPartition(), offset.getNextPartitionOffset());
+         PartitionOffset next = offset.getNextPartitionOffset();
+         Date cutoff = new Date(now.getTime() - getTimeBucketDurationMs());
+         if(next.getOffset().before(cutoff)) {
+            next = getPartitionOffsetFor(offset.getPartition(), cutoff);
+            completeOffset(next);
+         }
+         pending.put(offset.getPartition(), next);
       }
-      Date now = new Date();
       for(PlatformPartition partition: partitions) {
          pending.computeIfAbsent(partition, (p) -> getPartitionOffsetFor(p, now));
       }


### PR DESCRIPTION
## Summary
  When the scheduler service has been offline for an extended period, the stored partition offsets in Cassandra can be far behind the current time. On startup, PartitionSchedulerJob.schedule() iterates every 60-second bucket from the stored offset to now, creating an EventSchedulerJob for each one. With a large gap
   (e.g. months/years), this exhausts the heap. The service then OOMs, restarts, reads the same stale offset, and loops forever.                                                                                                                                                                                            
                                         
  `getPendingPartitions()` now detects offsets older than now - bucketSize, fast-forwards them, and persists the updated offset to Cassandra. The current bucket is preserved so recent events are not dropped.

  Pair with scheduler.sanity.check=true to recalculate schedulers that had past-due fire times in the skipped buckets.


                                                                      
   ## Test plan                                                           
   - [x] Start scheduler service with stale partition offsets in Cassandra           
   - [x] Verify offsets are fast-forwarded to current time without OOM
   - [x] Verify offsets are persisted so restarts don't repeat the problem
   - [x] Enable `scheduler.sanity.check=true` and verify stuck schedulers recalculate

   🤖 Generated with [Claude Code](https://claude.com/claude-code)"
