### PR TITLE
Build on arcus-smart-home and add snapshot suffix to version when not using a tag

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -47,6 +47,7 @@ ext.version_major = version_props.major
 ext.version_minor = version_props.minor
 ext.version_patch = version_props.patch
 ext.version_qualifier = version_props.qualifier
+apply from: file("${rootDir}/gradle/snapshot.gradle")
 
 version = "${version_major}.${version_minor}.${version_patch}${version_qualifier}"
 println "Building ${project.name} v${version}"

--- a/gradle/snapshot.gradle
+++ b/gradle/snapshot.gradle
@@ -1,0 +1,15 @@
+// Auto-detect SNAPSHOT qualifier from git state.
+// If HEAD is an exact tag match, use no qualifier (release build).
+// Otherwise, append -SNAPSHOT to indicate a development build.
+// This overrides the qualifier from version.properties.
+
+def isTagged = false
+try {
+   def proc = 'git describe --exact-match --tags HEAD'.execute(null, rootDir)
+   proc.waitFor()
+   isTagged = (proc.exitValue() == 0)
+} catch (Exception e) {
+   // git not available, default to SNAPSHOT
+}
+
+ext.version_qualifier = isTagged ? '' : '-SNAPSHOT'

--- a/khakis/bin/release.sh
+++ b/khakis/bin/release.sh
@@ -3,9 +3,10 @@ set -e
 ROOT=$(git rev-parse --show-toplevel)
 GRADLE=$ROOT/gradlew
 
-if [[ "${GITHUB_REPOSITORY}" != 'wl-net/arcusplatform' ]]; then
-  exit 0  # skip due to not being on a known repo
-fi
+case "${GITHUB_REPOSITORY}" in
+  wl-net/arcusplatform|arcus-smart-home/arcusplatform) ;;
+  *) exit 0  # skip due to not being on a known repo ;;
+esac
 
 echo "Building and publishing containers to '${REGISTRY_NAME}'"
 

--- a/khakis/build-release.gradle
+++ b/khakis/build-release.gradle
@@ -13,6 +13,7 @@ rootProject.ext.version_major = version_props.major
 rootProject.ext.version_minor = version_props.minor
 rootProject.ext.version_patch = version_props.patch
 rootProject.ext.version_qualifier = version_props.qualifier
+apply from: file("${rootDir}/gradle/snapshot.gradle")
 
 def loadBuild() {
    return new File("${buildFile}").text;

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -54,6 +54,7 @@ ext.version_major = version_props.major
 ext.version_minor = version_props.minor
 ext.version_patch = version_props.patch
 ext.version_qualifier = version_props.qualifier
+apply from: file("${rootDir}/gradle/snapshot.gradle")
 
 // full version numbers
 ext.buildVersion = "${version_major}.${version_minor}.${version_patch}${version_qualifier}"

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -69,6 +69,7 @@ ext.version_major = version_props.major
 ext.version_minor = version_props.minor
 ext.version_patch = version_props.patch
 ext.version_qualifier = version_props.qualifier
+apply from: file("${rootDir}/gradle/snapshot.gradle")
 
 // full version numbers
 ext.buildVersion = "${version_major}.${version_minor}.${version_patch}${version_qualifier}"

--- a/tools/version.properties
+++ b/tools/version.properties
@@ -1,4 +1,4 @@
 major=2
 minor=1
 patch=0
-qualifier=-SNAPSHOT
+qualifier=


### PR DESCRIPTION
Derive the version qualifier from git state instead of manually managing it in version.properties. If HEAD matches an exact tag, the build produces a clean version (e.g. 2026.2.0). Otherwise it appends -SNAPSHOT automatically.

Also add arcus-smart-home to the list of permitted orgs in release.sh.