### PR TITLE
Skip test workflow on tag pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Tests
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - '**'
+    branches:
+      - '**'
 jobs:
   Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The release workflow already runs tests on tag pushes, so the separate test workflow was running them a second time. Exclude tag pushes from the test workflow trigger.