### PR TITLE
Migrate from gradle-docker to bmuschko gradle-docker-plugin

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -28,7 +28,7 @@ dependencies {
    
    classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5"
    classpath "com.netflix.nebula:gradle-contacts-plugin:3.0.1"
-   classpath 'se.transmode.gradle:gradle-docker:1.2'
+   classpath 'com.bmuschko:gradle-docker-plugin:6.7.0'
    classpath "org.ajoberstar.grgit:grgit-gradle:4.1.1"
    classpath "org.owasp:dependency-check-gradle:5.2.2"
    classpath "com.github.spotbugs:spotbugs-gradle-plugin:4.8.0"

--- a/gradle/container.gradle
+++ b/gradle/container.gradle
@@ -11,8 +11,11 @@ import java.security.MessageDigest
 import groovy.io.FileType
 import java.nio.file.Files;
 
-
 apply from: file("${rootDir}/gradle/application.gradle")
+apply plugin: 'com.bmuschko.docker-remote-api'
+
+def DockerfileTask = project.buildscript.classLoader.loadClass('com.bmuschko.gradle.docker.tasks.image.Dockerfile')
+def DockerBuildImageTask = project.buildscript.classLoader.loadClass('com.bmuschko.gradle.docker.tasks.image.DockerBuildImage')
 
 project.ext.dockerGroup = 'arcus'
 project.ext.containerName = "${project.name}.${project.dockerGroup}"
@@ -76,23 +79,26 @@ task uberDocker {
 }
 
 
-docker {
-   baseImage "arcus/java"
-}
-
-distDocker {
-   tag = project.containerTag;
-   tagVersion = project.dockerVersion;
-
+task createDockerfile(type: DockerfileTask) {
+   destFile = project.file("${buildDir}/docker/Dockerfile")
+   from 'arcus/java'
+   addFile "${applicationName}-${version}.tar.gz", '/'
+   entryPoint "/${applicationName}-${version}/bin/${applicationName}"
    def irisConfig = '/' + applicationName + '-' + version + '/conf/' + applicationName + '.properties'
-   defaultCommand(['-c', irisConfig])
+   defaultCommand '-c', irisConfig
 }
 
-// The gradle-docker plugin v1.2 calls JavaBaseImage.imageFor(targetCompatibility)
-// which throws for Java 11+ since it only supports Java 6/7/8. Temporarily set
-// targetCompatibility to 1.8 before the task action runs so the lookup succeeds,
-// then the docker{} extension baseImage "arcus/java" is used as the actual image.
-distDocker.doFirst { project.targetCompatibility = '1.8' }
+task prepareDockerContext(type: Copy) {
+   dependsOn distTar
+   from distTar.archivePath
+   into "${buildDir}/docker"
+}
+
+task distDocker(type: DockerBuildImageTask) {
+   dependsOn createDockerfile, prepareDockerContext
+   inputDir = project.file("${buildDir}/docker")
+   images.add("${project.containerTag}:${project.dockerVersion}")
+}
 
 task tagDocker(type: Exec) {
    dependsOn "distDocker"

--- a/gradle/subproject.gradle
+++ b/gradle/subproject.gradle
@@ -14,7 +14,6 @@ repositories {
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'docker'
 apply plugin: 'nebula.contacts'
 apply plugin: 'project-report'
 apply plugin: 'eclipse'

--- a/platform/arcus-modelmanager/build.gradle
+++ b/platform/arcus-modelmanager/build.gradle
@@ -61,15 +61,29 @@ dependencies {
     runtime libraries.logback
 }   
 
-docker {
-   baseImage "arcus/java"
+apply plugin: 'com.bmuschko.docker-remote-api'
+
+def DockerfileTask = project.buildscript.classLoader.loadClass('com.bmuschko.gradle.docker.tasks.image.Dockerfile')
+def DockerBuildImageTask = project.buildscript.classLoader.loadClass('com.bmuschko.gradle.docker.tasks.image.DockerBuildImage')
+
+task createDockerfile(type: DockerfileTask) {
+   destFile = project.file("${buildDir}/docker/Dockerfile")
+   from 'arcus/java'
+   addFile "${applicationName}-${version}.tar.gz", '/'
+   entryPoint "/${applicationName}-${version}/bin/${applicationName}"
+   defaultCommand '-H', "/${applicationName}-${version}/", '-P', 'dev', '-a'
 }
 
-distDocker {
-   tag = "${project.dockerGroup}/${project.applicationName}"
-   tagVersion = dockerVersion
-   
-   defaultCommand(["-H", "/${project.applicationName}-${project.version}/", "-P", "dev", "-a"])
+task prepareDockerContext(type: Copy) {
+   dependsOn distTar
+   from distTar.archivePath
+   into "${buildDir}/docker"
+}
+
+task distDocker(type: DockerBuildImageTask) {
+   dependsOn createDockerfile, prepareDockerContext
+   inputDir = project.file("${buildDir}/docker")
+   images.add("${project.containerTag}:${dockerVersion}")
 }
 
 task tagDocker(type: Exec) {

--- a/tools/arcus-captools/build.gradle
+++ b/tools/arcus-captools/build.gradle
@@ -45,10 +45,6 @@ dependencies {
     compile project(':common:arcus-model')
 }
 
-docker {
-    baseImage "arcus/java"
-}
-
 tasks.addRule("Pattern: <CodeGenerationType>Code") {
     String taskName ->
         if (taskName.toLowerCase().startsWith("htmlcode")) {


### PR DESCRIPTION
The gradle-docker plugin is abandoned (~2015), hosted on dead bintray, and only supports Java 6/7/8 requiring various hacks to work on Java 11. Replace it with bmuschko's docker-remote-api plugin using Dockerfile + DockerBuildImage tasks that preserve the existing image layout (dist tar, start script entrypoint, config path CMD).

- buildscript.gradle: swap classpath dependency
- subproject.gradle: remove global `apply plugin: 'docker'`
- container.gradle: replace docker{}/distDocker{} with bmuschko tasks
- arcus-modelmanager: same pattern with custom CMD args
- arcus-captools: remove dead docker{} block (not a container)


Built on arcus-dev and rolled containers on a staging cluster. Files appear to be in correct location and are working normally.