### PR TITLE
Use arcus/java base image for Cassandra container

### DIFF
--- a/khakis/arcus-cassandra/Dockerfile
+++ b/khakis/arcus-cassandra/Dockerfile
@@ -1,26 +1,18 @@
-# Use Debian Bookworm with Java 11 for Cassandra 4.x
-FROM debian:bookworm
+# Use the standard arcus java image
+FROM arcus/java
 
-# Setup the default locale to be UTF-8
-RUN apt-get update && apt-get install -y locales ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+USER root
 
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-
-# Install Java 11
+# Initial system configuration
+#  python3 is required to run cqlsh
+#  unzip is required to unzip the modelmanager jar
 RUN \
-    wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb bookworm main" > /etc/apt/sources.list.d/adoptium.list && \
     apt-get update && \
-    apt-get install -y temurin-11-jre \
-        python3 \
-        dnsutils \
-        unzip \
-        procps && \
-    useradd -M -U -r -s /bin/false cassandra && \
-    apt-get remove -y wget && \
-    apt-get clean && \
+    apt-get install -y \
+      wget \
+      python3 \
+      dnsutils \
+      unzip && \
     rm -rf /var/lib/apt/lists/*
 
 # Environment variables for configuration
@@ -28,16 +20,12 @@ ENV CASSANDRA_VERSION 4.0.15
 
 # Download and install the required version of Apache Cassandra.
 RUN \
-    apt-get update && apt-get install -y wget && \
     wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -O /tmp/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz && \
     tar xfz /tmp/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C /opt && \
     ln -s /opt/apache-cassandra-${CASSANDRA_VERSION} /opt/cassandra && \
     rm /tmp/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz && \
     ln -s /opt/cassandra/bin/cqlsh /usr/bin && \
-    ln -s /opt/cassandra/bin/nodetool /usr/bin && \
-    apt-get remove -y wget && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    ln -s /opt/cassandra/bin/nodetool /usr/bin
 
 # Add control script
 ADD cassandra-cmd /usr/bin/


### PR DESCRIPTION
The Cassandra 4.0 upgrade  switched from arcus/java to debian:bookworm for Python 2 support and duplicated the Java/locale setup. Restore the original pattern used by all other khakis containers now that we can work with Python 3. 