### PR TITLE
Cleanup unused deps

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -85,6 +85,12 @@ ext.libraries << [
 		azure_storage: "com.microsoft.azure:azure-storage:3.0.0",
 		javaxServlet: "javax.servlet:javax.servlet-api:3.1.0",
 		sunrise_sunset_calc: "com.luckycatlabs:SunriseSunsetCalculator:1.2",
+
+// JAXB Dependencies
+		jaxb_xjc: "com.sun.xml.bind:jaxb-xjc:2.2.7-b41",
+		jaxb_impl: "com.sun.xml.bind:jaxb-impl:2.2.7-b41",
+		jaxb_api: "javax.xml.bind:jaxb-api:2.2.7",
+
 // Encryption via Bouncy Castle
 		bouncycastle: "org.bouncycastle:bcprov-jdk18on:1.78",
 		bouncycastle_pki: "org.bouncycastle:bcpkix-jdk18on:1.78",


### PR DESCRIPTION
None of these are in current use, but pollute vulnerability reporting. Remove them.