### PR TITLE
Fix race condition in TestDriverBindingsWrapAsHandler

### DIFF
--- a/platform/arcus-platform-drivers/driver-tests/src/test/java/com/iris/driver/groovy/TestDriverBindingsWrapAsHandler.java
+++ b/platform/arcus-platform-drivers/driver-tests/src/test/java/com/iris/driver/groovy/TestDriverBindingsWrapAsHandler.java
@@ -64,6 +64,9 @@ public class TestDriverBindingsWrapAsHandler extends GroovyDriverTestCase {
          }
       };
       final ContextualEventHandler<Object> handler = DriverBinding.wrapAsHandler(closure);
+      for(int i=0; i<count; i++) {
+         keys.add(i);
+      }
       List<Future<?>> results = new ArrayList<>(count);
       for(int i=0; i<count; i++) {
          final int index = i;
@@ -75,7 +78,6 @@ public class TestDriverBindingsWrapAsHandler extends GroovyDriverTestCase {
             }
          });
          results.add(result);
-         keys.add(index);
       }
       int succeeded = 0;
       for(Future<?> result: results) {


### PR DESCRIPTION
Populate the keys set before submitting tasks to the executor, not after. Previously keys.add(index) ran after executor.submit(), so the last task could count down the latch, release all threads, and call keys.remove() before the main thread added the key causing an assertion failure.