### PR TITLE
Trim CORS header values to fix 502 with Origin header after Netty upgrade

### DIFF
--- a/platform/bridge-common/src/main/java/com/iris/netty/server/netty/IrisNettyCorsConfig.java
+++ b/platform/bridge-common/src/main/java/com/iris/netty/server/netty/IrisNettyCorsConfig.java
@@ -72,8 +72,8 @@ public class IrisNettyCorsConfig {
    // on every http request
    @PostConstruct
    public void init() {
-      exposeRequest = split(exposeRequestHeaders, false);
-      allowRequest = split(allowRequestHeaders, false);
+      exposeRequest = split(exposeRequestHeaders, true);
+      allowRequest = split(allowRequestHeaders, true);
       String[] splitMethods = split(allowRequestMethods, false);
       allowMethods = new HttpMethod[splitMethods.length];
       for(int i = 0; i < splitMethods.length; i++) {


### PR DESCRIPTION
The expose and allow header config strings (e.g. "accept, accept-encoding") were split on comma without trimming, producing values like ` accept-encoding` with a leading space. Netty 4.1.48 accepted this, but 4.1.128's stricter HttpHeaderValidationUtil.validateValidHeaderValue() requires the first character to be a visible printing char (0x21-0x7E), so the leading space throws an exception in CorsHandler.write() when setting CORS response headers.