### PR TITLE
Upgrade Apache Shiro 1.3.2 → 1.13.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -184,8 +184,8 @@ ext.libraries << [
 		junit: "junit:junit:4.13.2",
 
 // Apache Shiro
-		shiro: "org.apache.shiro:shiro-core:1.3.2",
-		shiro_guice: "org.apache.shiro:shiro-guice:1.3.2",
+		shiro: "org.apache.shiro:shiro-core:1.13.0",
+		shiro_guice: "org.apache.shiro:shiro-guice:1.13.0",
 
 // Logging
 		slf4j: "org.slf4j:jcl-over-slf4j:2.0.17",

--- a/gradle/subproject.gradle
+++ b/gradle/subproject.gradle
@@ -39,10 +39,16 @@ apply from: file("${rootDir}/gradle/dependencies.gradle")
 
 // Guava 32+ publishes Gradle Module Metadata with JRE and Android variants.
 // Explicitly select the standard-jvm (JRE) variant on all configurations.
+// Also pin Guice to 4.0 — shiro-guice 1.13.0 transitively requests 4.2.3 which
+// has stricter null-checking for @Provides methods, breaking existing tests.
 configurations.all {
    attributes {
       attribute(org.gradle.api.attributes.java.TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
                objects.named(org.gradle.api.attributes.java.TargetJvmEnvironment, org.gradle.api.attributes.java.TargetJvmEnvironment.STANDARD_JVM))
+   }
+   resolutionStrategy {
+      force 'com.google.inject:guice:4.0'
+      force 'com.google.inject.extensions:guice-multibindings:4.0'
    }
 }
 

--- a/platform/bridge-common/src/test/java/com/iris/bridge/server/client/TestBindClientContextHandler.java
+++ b/platform/bridge-common/src/test/java/com/iris/bridge/server/client/TestBindClientContextHandler.java
@@ -25,12 +25,17 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 
+import java.util.UUID;
+
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.session.UnknownSessionException;
 import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.session.mgt.eis.SessionDAO;
+import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.support.DefaultSubjectContext;
 import org.easymock.EasyMock;
+
+import com.iris.security.principal.DefaultPrincipal;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -105,6 +110,7 @@ public class TestBindClientContextHandler extends IrisTestCase {
       session.setId("test");
       session.setExpired(false);
       session.setAttribute(DefaultSubjectContext.AUTHENTICATED_SESSION_KEY, true);
+      session.setAttribute(DefaultSubjectContext.PRINCIPALS_SESSION_KEY, new SimplePrincipalCollection(new DefaultPrincipal("test", UUID.randomUUID()), "irisRealm"));
       
       EasyMock
          .expect(sessionDao.readSession("test"))
@@ -140,6 +146,7 @@ public class TestBindClientContextHandler extends IrisTestCase {
       session.setId("test");
       session.setExpired(false);
       session.setAttribute(DefaultSubjectContext.AUTHENTICATED_SESSION_KEY, true);
+      session.setAttribute(DefaultSubjectContext.PRINCIPALS_SESSION_KEY, new SimplePrincipalCollection(new DefaultPrincipal("test", UUID.randomUUID()), "irisRealm"));
       
       EasyMock
          .expect(sessionDao.readSession("test"))


### PR DESCRIPTION
   ## Summary
   - Upgrade Apache Shiro from 1.3.2 to 1.13.0
   - Pin Guice to 4.0 to prevent shiro-guice 1.13.0 from transitively pulling in Guice 4.2.3, which has stricter null-checking for `@Provides` methods that breaks existing code
   - Update `TestBindClientContextHandler` to set `PRINCIPALS_SESSION_KEY` alongside `AUTHENTICATED_SESSION_KEY` on test sessions

   ### Why the test change?

   SHIRO-661 ([SHIRO-661](https://issues.apache.org/jira/browse/SHIRO-661), [commit 148eeb7f](https://github.com/apache/shiro/commit/148eeb7f4620a1da026cd04b3b499bbe1897989f)) changed `DelegatingSubject.isAuthenticated()` from `return authenticated` to
    `return authenticated && hasPrincipals()`. This was to prevent NPEs when servlet containers lose non-serializable principals across restarts while the auth flag survives in the session.

   The existing tests only set `AUTHENTICATED_SESSION_KEY` on mock sessions without setting `PRINCIPALS_SESSION_KEY`. With Shiro 1.3.2 that was enough for `isAuthenticated()` to return true. With 1.13.0 it returns false because there are no principals,
    causing `testBindByCookie` and `testBindByAuthHeader` to fail.

   This matches real behavior — Cassandra sessions always have both keys stored together in the same row, so production was never affected.

   ## Test plan
   - [x] `TestBindClientContextHandler` passes (4/4)
   - [x] Deploy and verify login + session reconnection work end-to-end