### PR TITLE
Add slf4j-nop provider to reflex generator runtime

### DIFF
--- a/platform/arcus-containers/driver-services/build.gradle
+++ b/platform/arcus-containers/driver-services/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     reflexGeneratorRuntime libraries.jacksonCore
     reflexGeneratorRuntime libraries.jacksonDatabind
     reflexGeneratorRuntime libraries.slf4jApi
+    reflexGeneratorRuntime 'org.slf4j:slf4j-nop:2.0.17'
     reflexGeneratorRuntime libraries.guiceCore
     reflexGeneratorRuntime libraries.guava
     reflexGeneratorRuntime libraries.groovy


### PR DESCRIPTION
The reflexGeneratorRuntime configuration includes slf4j-api but no provider, causing SLF4J warnings during Gradle builds.