### PR TITLE
Fix stale build timestamp by disabling up-to-date check

### DIFF
--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -99,6 +99,7 @@ startScripts {
 task createApplicationInfo {
    def outputDir = file("${buildDir}/generated-resources/application-info")
    outputs.dir outputDir
+   outputs.upToDateWhen { false }
    doLast {
       def f = new File(outputDir, "META-INF/application.properties")
       f.delete()


### PR DESCRIPTION
The createApplicationInfo task declares outputs but no time-varying inputs, so Gradle skips it on incremental builds. Adding outputs.upToDateWhen { false } ensures the timestamp and commit hash are regenerated on every build.