### PR TITLE
Reduce Cassandra 4.x log verbosity with configurable log level

### DIFF
--- a/khakis/arcus-cassandra/Dockerfile
+++ b/khakis/arcus-cassandra/Dockerfile
@@ -27,9 +27,10 @@ RUN \
     ln -s /opt/cassandra/bin/cqlsh /usr/bin && \
     ln -s /opt/cassandra/bin/nodetool /usr/bin
 
-# Add control script
+# Add control script and logging configuration
 ADD cassandra-cmd /usr/bin/
 ADD cassandra-provision /usr/bin/
+ADD logback.xml /opt/apache-cassandra-${CASSANDRA_VERSION}/conf/logback.xml
 
 # Define working directory.
 WORKDIR /data

--- a/khakis/arcus-cassandra/logback.xml
+++ b/khakis/arcus-cassandra/logback.xml
@@ -1,0 +1,16 @@
+<configuration scan="true" scanPeriod="60 seconds">
+  <jmxConfigurator />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${CASSANDRA_LOG_LEVEL:-WARN}</level>
+    </filter>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Ship a custom logback.xml that defaults to WARN level, replacing the upstream default of INFO which is very chatty in 4.0. The log level is configurable at runtime via the CASSANDRA_LOG_LEVEL env var.