### PR TITLE
Re-introduce DeleteApiKeyHandler and add handler unit tests

### DIFF
--- a/common/arcus-model/src/main/resources/service/apikeyservice.xml
+++ b/common/arcus-model/src/main/resources/service/apikeyservice.xml
@@ -72,6 +72,25 @@
 
       </s:method>
 
+      <s:method
+         name="Delete"
+         description="Deletes a revoked API key. The key must be revoked before it can be deleted."
+         isRESTful="false">
+
+         <s:parameter
+            name="placeId"
+            type="string"
+            description="The place the API key belongs to"
+            optional="false"/>
+
+         <s:parameter
+            name="id"
+            type="string"
+            description="The UUID of the API key to delete"
+            optional="false"/>
+
+      </s:method>
+
    </s:methods>
 
 </s:service>

--- a/docs/api-bridge.md
+++ b/docs/api-bridge.md
@@ -6,7 +6,7 @@ Each API key is scoped to a single place and carries a fixed set of permissions.
 
 ## API Key Management
 
-API keys are managed by sending messages to the place service (`base:place`). Only the account owner can create, revoke, and list keys.
+API keys are managed by sending messages to the place service (`base:place`). Only the account owner can create, list, revoke, and delete keys.
 
 ### Create
 
@@ -51,6 +51,20 @@ Send `apikey:ListKeys` to the place address. Returns all keys for the place with
 ### Revoke
 
 Send `apikey:Revoke` with the key's `id`. This sets `expiresAt` to the current time, immediately expiring the key. All active WebSocket sessions using the revoked key are disconnected. The key record is preserved for auditing.
+
+### Delete
+
+Send `apikey:Delete` with the key's `id`. This permanently removes the key record. The key must be revoked before it can be deleted — attempting to delete an active key returns an error.
+
+```json
+{
+  "type": "apikey:Delete",
+  "destination": "SERV:place:<placeId>",
+  "attributes": {
+    "id": "a1b2c3d4-..."
+  }
+}
+```
 
 ## Authentication
 
@@ -137,4 +151,4 @@ Default configuration (`api-bridge.properties`):
 - **Place isolation** — a key can only access resources within its assigned place. The active place is locked at session creation and cannot be changed.
 - **Immediate revocation** — revoking a key disconnects all active sessions using it across all api-bridge instances (via platform bus event).
 - **Per-place limits** — maximum 10 keys per place to prevent abuse.
-- **Account owner only** — only the account owner can create, revoke, and list API keys.
+- **Account owner only** — only the account owner can create, list, revoke, and delete API keys.

--- a/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/apikey/ApiKeyServiceModule.java
+++ b/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/apikey/ApiKeyServiceModule.java
@@ -23,6 +23,7 @@ import com.iris.bootstrap.guice.AbstractIrisModule;
 import com.iris.core.platform.ContextualRequestMessageHandler;
 import com.iris.messages.model.Place;
 import com.iris.platform.services.apikey.handlers.CreateApiKeyHandler;
+import com.iris.platform.services.apikey.handlers.DeleteApiKeyHandler;
 import com.iris.platform.services.apikey.handlers.ListApiKeysHandler;
 import com.iris.platform.services.apikey.handlers.RevokeApiKeyHandler;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ public class ApiKeyServiceModule extends AbstractIrisModule {
       Multibinder<ContextualRequestMessageHandler<Place>> handlerBinder =
             bindSetOf(new TypeLiteral<ContextualRequestMessageHandler<Place>>() {});
       handlerBinder.addBinding().to(CreateApiKeyHandler.class);
+      handlerBinder.addBinding().to(DeleteApiKeyHandler.class);
       handlerBinder.addBinding().to(ListApiKeysHandler.class);
       handlerBinder.addBinding().to(RevokeApiKeyHandler.class);
    }

--- a/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/apikey/handlers/DeleteApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/main/java/com/iris/platform/services/apikey/handlers/DeleteApiKeyHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.iris.platform.services.apikey.handlers;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.iris.core.dao.AccountDAO;
+import com.iris.core.dao.ApiKeyDAO;
+import com.iris.core.platform.ContextualRequestMessageHandler;
+import com.iris.messages.MessageBody;
+import com.iris.messages.PlatformMessage;
+import com.iris.messages.errors.ErrorEventException;
+import com.iris.messages.errors.Errors;
+import com.iris.security.authz.AuthzUtil;
+import com.iris.messages.model.Account;
+import com.iris.messages.model.Place;
+import com.iris.security.apikey.ApiKey;
+
+@Singleton
+public class DeleteApiKeyHandler implements ContextualRequestMessageHandler<Place> {
+
+   public static final String MESSAGE_TYPE = "apikey:Delete";
+
+   private final ApiKeyDAO apiKeyDao;
+   private final AccountDAO accountDao;
+
+   @Inject
+   public DeleteApiKeyHandler(ApiKeyDAO apiKeyDao, AccountDAO accountDao) {
+      this.apiKeyDao = apiKeyDao;
+      this.accountDao = accountDao;
+   }
+
+   @Override
+   public String getMessageType() {
+      return MESSAGE_TYPE;
+   }
+
+   @Override
+   public MessageBody handleRequest(Place context, PlatformMessage msg) {
+      requireAccountOwner(context, msg);
+
+      MessageBody body = msg.getValue();
+
+      String idStr = (String) body.getAttributes().get("id");
+      if (StringUtils.isBlank(idStr)) {
+         throw new ErrorEventException(Errors.CODE_MISSING_PARAM, "id is required");
+      }
+
+      UUID keyId;
+      try {
+         keyId = UUID.fromString(idStr);
+      } catch (IllegalArgumentException e) {
+         throw new ErrorEventException(Errors.CODE_INVALID_PARAM, "id must be a valid UUID");
+      }
+
+      ApiKey existing = null;
+      for (ApiKey key : apiKeyDao.findByPlace(context.getId())) {
+         if (key.getId().equals(keyId)) {
+            existing = key;
+            break;
+         }
+      }
+
+      if (existing == null) {
+         throw new ErrorEventException(Errors.CODE_NOT_FOUND, "API key not found");
+      }
+
+      if (!existing.isExpired()) {
+         throw new ErrorEventException(Errors.CODE_INVALID_PARAM, "API key must be revoked before it can be deleted");
+      }
+
+      apiKeyDao.delete(context.getId(), keyId, existing.getKeyHash());
+
+      return MessageBody.buildMessage("apikey:DeleteResponse", Collections.emptyMap());
+   }
+
+   private void requireAccountOwner(Place place, PlatformMessage msg) {
+      if (msg.getActor() == null) {
+         throw new ErrorEventException(Errors.CODE_INVALID_REQUEST, "actor is required");
+      }
+
+      Account account = accountDao.findById(place.getAccount());
+      if (account == null) {
+         throw new ErrorEventException(Errors.CODE_NOT_FOUND, "account not found");
+      }
+
+      UUID actorId = (UUID) msg.getActor().getId();
+      if (!Objects.equals(actorId, account.getOwner())) {
+         throw new ErrorEventException(AuthzUtil.UNAUTHORIZED_CODE, "only the account owner can manage API keys");
+      }
+   }
+}

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestCreateApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestCreateApiKeyHandler.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.iris.platform.services.apikey.handlers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import com.google.inject.Inject;
+import com.iris.core.dao.AccountDAO;
+import com.iris.core.dao.ApiKeyDAO;
+import com.iris.core.messaging.memory.InMemoryMessageModule;
+import com.iris.messages.MessageBody;
+import com.iris.messages.PlatformMessage;
+import com.iris.messages.address.Address;
+import com.iris.messages.errors.ErrorEventException;
+import com.iris.messages.errors.Errors;
+import com.iris.messages.model.Account;
+import com.iris.messages.model.Place;
+import com.iris.security.apikey.ApiKey;
+import com.iris.security.authz.AuthzUtil;
+import com.iris.test.IrisMockTestCase;
+import com.iris.test.Mocks;
+import com.iris.test.Modules;
+
+@Mocks({ApiKeyDAO.class, AccountDAO.class})
+@Modules({InMemoryMessageModule.class})
+public class TestCreateApiKeyHandler extends IrisMockTestCase {
+
+   @Inject ApiKeyDAO apiKeyDao;
+   @Inject AccountDAO accountDao;
+
+   private CreateApiKeyHandler handler;
+   private Place place;
+   private Account account;
+   private UUID ownerId;
+
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      handler = new CreateApiKeyHandler(apiKeyDao, accountDao);
+
+      ownerId = UUID.randomUUID();
+
+      account = new Account();
+      account.setId(UUID.randomUUID());
+      account.setOwner(ownerId);
+
+      place = new Place();
+      place.setId(UUID.randomUUID());
+      place.setAccount(account.getId());
+      place.setName("Test Place");
+      place.setPopulation("general");
+   }
+
+   @Override
+   public void tearDown() throws Exception {
+      verify();
+      super.tearDown();
+   }
+
+   @Test
+   public void testCreateSuccess() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.emptyList());
+      Capture<ApiKey> savedKey = EasyMock.newCapture();
+      apiKeyDao.save(EasyMock.capture(savedKey));
+      EasyMock.expectLastCall();
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      PlatformMessage msg = buildRequest(ownerId, "test-label", perms, null);
+
+      MessageBody response = handler.handleRequest(place, msg);
+      assertEquals("apikey:CreateResponse", response.getMessageType());
+      assertNotNull(response.getAttributes().get("id"));
+      assertNotNull(response.getAttributes().get("key"));
+      String key = (String) response.getAttributes().get("key");
+      assertTrue(key.startsWith("arcus_sk_"));
+
+      ApiKey captured = savedKey.getValue();
+      assertEquals("test-label", captured.getLabel());
+      assertEquals(place.getId(), captured.getPlaceId());
+      assertTrue(captured.getPermissions().contains("device:*"));
+      assertNull(captured.getExpiresAt());
+   }
+
+   @Test
+   public void testCreateWithExpiration() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.emptyList());
+      Capture<ApiKey> savedKey = EasyMock.newCapture();
+      apiKeyDao.save(EasyMock.capture(savedKey));
+      EasyMock.expectLastCall();
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      long futureTime = System.currentTimeMillis() + 86400000L; // 1 day from now
+      PlatformMessage msg = buildRequest(ownerId, "expiring-key", perms, futureTime);
+
+      MessageBody response = handler.handleRequest(place, msg);
+      assertEquals("apikey:CreateResponse", response.getMessageType());
+
+      ApiKey captured = savedKey.getValue();
+      assertNotNull(captured.getExpiresAt());
+      assertEquals(futureTime, captured.getExpiresAt().getTime());
+   }
+
+   @Test
+   public void testCreateMissingLabel() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      PlatformMessage msg = buildRequest(ownerId, null, perms, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_MISSING_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateLabelTooLong() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      // 65-char label
+      String longLabel = String.join("", Collections.nCopies(65, "a"));
+      PlatformMessage msg = buildRequest(ownerId, longLabel, perms, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateMissingPermissions() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, "test-label", null, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_MISSING_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateEmptyPermissions() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, "test-label", Collections.emptySet(), null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateInvalidPermission() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add(""); // blank permission
+      PlatformMessage msg = buildRequest(ownerId, "test-label", perms, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateExceedsKeyLimit() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      List<ApiKey> existingKeys = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+         ApiKey key = new ApiKey();
+         key.setId(UUID.randomUUID());
+         existingKeys.add(key);
+      }
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(existingKeys);
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      PlatformMessage msg = buildRequest(ownerId, "test-label", perms, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals("apikey.limit_reached", e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateNotOwner() {
+      UUID nonOwnerId = UUID.randomUUID();
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      PlatformMessage msg = buildRequest(nonOwnerId, "test-label", perms, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(AuthzUtil.UNAUTHORIZED_CODE, e.getCode());
+      }
+   }
+
+   @Test
+   public void testCreateExpiredInPast() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.emptyList());
+      replay();
+
+      Set<String> perms = new HashSet<>();
+      perms.add("device:*");
+      long pastTime = System.currentTimeMillis() - 86400000L; // 1 day ago
+      PlatformMessage msg = buildRequest(ownerId, "test-label", perms, pastTime);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   private PlatformMessage buildRequest(UUID actorId, String label, Set<String> permissions, Long expiresAt) {
+      Map<String, Object> attrs = new HashMap<>();
+      if (label != null) {
+         attrs.put("label", label);
+      }
+      if (permissions != null) {
+         attrs.put("permissions", permissions);
+      }
+      if (expiresAt != null) {
+         attrs.put("expiresAt", expiresAt);
+      }
+
+      MessageBody body = MessageBody.buildMessage(CreateApiKeyHandler.MESSAGE_TYPE, attrs);
+      return PlatformMessage.buildMessage(
+            body,
+            Address.clientAddress("test", "1"),
+            Address.fromString(place.getAddress()))
+            .withActor(Address.platformService(actorId, "person"))
+            .create();
+   }
+}

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestDeleteApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestDeleteApiKeyHandler.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.iris.platform.services.apikey.handlers;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import com.google.inject.Inject;
+import com.iris.core.dao.AccountDAO;
+import com.iris.core.dao.ApiKeyDAO;
+import com.iris.core.messaging.memory.InMemoryMessageModule;
+import com.iris.messages.MessageBody;
+import com.iris.messages.PlatformMessage;
+import com.iris.messages.address.Address;
+import com.iris.messages.errors.ErrorEventException;
+import com.iris.messages.errors.Errors;
+import com.iris.messages.model.Account;
+import com.iris.messages.model.Place;
+import com.iris.security.apikey.ApiKey;
+import com.iris.security.authz.AuthzUtil;
+import com.iris.test.IrisMockTestCase;
+import com.iris.test.Mocks;
+import com.iris.test.Modules;
+
+@Mocks({ApiKeyDAO.class, AccountDAO.class})
+@Modules({InMemoryMessageModule.class})
+public class TestDeleteApiKeyHandler extends IrisMockTestCase {
+
+   @Inject ApiKeyDAO apiKeyDao;
+   @Inject AccountDAO accountDao;
+
+   private DeleteApiKeyHandler handler;
+   private Place place;
+   private Account account;
+   private UUID ownerId;
+
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      handler = new DeleteApiKeyHandler(apiKeyDao, accountDao);
+
+      ownerId = UUID.randomUUID();
+
+      account = new Account();
+      account.setId(UUID.randomUUID());
+      account.setOwner(ownerId);
+
+      place = new Place();
+      place.setId(UUID.randomUUID());
+      place.setAccount(account.getId());
+      place.setName("Test Place");
+      place.setPopulation("general");
+   }
+
+   @Override
+   public void tearDown() throws Exception {
+      verify();
+      super.tearDown();
+   }
+
+   @Test
+   public void testDeleteSuccess() {
+      UUID keyId = UUID.randomUUID();
+      ApiKey existing = createExpiredKey(keyId);
+
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.singletonList(existing));
+      apiKeyDao.delete(place.getId(), keyId, "keyhash123");
+      EasyMock.expectLastCall();
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, keyId.toString());
+      MessageBody response = handler.handleRequest(place, msg);
+
+      assertEquals("apikey:DeleteResponse", response.getMessageType());
+   }
+
+   @Test
+   public void testDeleteMissingId() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_MISSING_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testDeleteNotFound() {
+      UUID keyId = UUID.randomUUID();
+
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.emptyList());
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, keyId.toString());
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_NOT_FOUND, e.getCode());
+      }
+   }
+
+   @Test
+   public void testDeleteNotRevoked() {
+      UUID keyId = UUID.randomUUID();
+      ApiKey existing = createActiveKey(keyId);
+
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.singletonList(existing));
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, keyId.toString());
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testDeleteNotOwner() {
+      UUID nonOwnerId = UUID.randomUUID();
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(nonOwnerId, UUID.randomUUID().toString());
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(AuthzUtil.UNAUTHORIZED_CODE, e.getCode());
+      }
+   }
+
+   private ApiKey createActiveKey(UUID keyId) {
+      ApiKey key = new ApiKey();
+      key.setId(keyId);
+      key.setPlaceId(place.getId());
+      key.setLabel("test-key");
+      key.setKeyPrefix("arcus_sk_0a1b2c3d");
+      key.setKeyHash("keyhash123");
+      key.setCreated(new Date());
+      // no expiresAt = not expired
+      return key;
+   }
+
+   private ApiKey createExpiredKey(UUID keyId) {
+      ApiKey key = createActiveKey(keyId);
+      key.setExpiresAt(new Date(System.currentTimeMillis() - 86400000L)); // expired yesterday
+      return key;
+   }
+
+   private PlatformMessage buildRequest(UUID actorId, String keyId) {
+      Map<String, Object> attrs = new HashMap<>();
+      if (keyId != null) {
+         attrs.put("id", keyId);
+      }
+
+      MessageBody body = MessageBody.buildMessage(DeleteApiKeyHandler.MESSAGE_TYPE, attrs);
+      return PlatformMessage.buildMessage(
+            body,
+            Address.clientAddress("test", "1"),
+            Address.fromString(place.getAddress()))
+            .withActor(Address.platformService(actorId, "person"))
+            .create();
+   }
+}

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestListApiKeysHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestListApiKeysHandler.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.iris.platform.services.apikey.handlers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import com.google.inject.Inject;
+import com.iris.core.dao.ApiKeyDAO;
+import com.iris.core.messaging.memory.InMemoryMessageModule;
+import com.iris.messages.MessageBody;
+import com.iris.messages.PlatformMessage;
+import com.iris.messages.address.Address;
+import com.iris.messages.model.Place;
+import com.iris.security.apikey.ApiKey;
+import com.iris.test.IrisMockTestCase;
+import com.iris.test.Mocks;
+import com.iris.test.Modules;
+
+@Mocks({ApiKeyDAO.class})
+@Modules({InMemoryMessageModule.class})
+public class TestListApiKeysHandler extends IrisMockTestCase {
+
+   @Inject ApiKeyDAO apiKeyDao;
+
+   private ListApiKeysHandler handler;
+   private Place place;
+
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      handler = new ListApiKeysHandler(apiKeyDao);
+
+      place = new Place();
+      place.setId(UUID.randomUUID());
+      place.setAccount(UUID.randomUUID());
+      place.setName("Test Place");
+      place.setPopulation("general");
+   }
+
+   @Override
+   public void tearDown() throws Exception {
+      verify();
+      super.tearDown();
+   }
+
+   @Test
+   public void testListEmpty() {
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.emptyList());
+      replay();
+
+      PlatformMessage msg = buildRequest();
+
+      MessageBody response = handler.handleRequest(place, msg);
+      assertEquals("apikey:ListKeysResponse", response.getMessageType());
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> keys = (List<Map<String, Object>>) response.getAttributes().get("keys");
+      assertNotNull(keys);
+      assertTrue(keys.isEmpty());
+   }
+
+   @SuppressWarnings("unchecked")
+   @Test
+   public void testListMultipleKeys() {
+      UUID key1Id = UUID.randomUUID();
+      UUID key2Id = UUID.randomUUID();
+      Date created1 = new Date(1700000000000L);
+      Date created2 = new Date(1700100000000L);
+      Date lastUsed = new Date(1700200000000L);
+      Date expiresAt = new Date(1600000000000L); // in the past = expired
+
+      ApiKey key1 = new ApiKey();
+      key1.setId(key1Id);
+      key1.setPlaceId(place.getId());
+      key1.setLabel("integration-1");
+      key1.setKeyPrefix("arcus_sk_0a1b2c3d");
+      key1.setKeyHash("hash1");
+      key1.setPermissions(new HashSet<>(Arrays.asList("device:*", "scene:*")));
+      key1.setCreated(created1);
+
+      ApiKey key2 = new ApiKey();
+      key2.setId(key2Id);
+      key2.setPlaceId(place.getId());
+      key2.setLabel("integration-2");
+      key2.setKeyPrefix("arcus_sk_4e5f6a7b");
+      key2.setKeyHash("hash2");
+      key2.setPermissions(new HashSet<>(Collections.singletonList("device:get")));
+      key2.setCreated(created2);
+      key2.setLastUsed(lastUsed);
+      key2.setExpiresAt(expiresAt);
+
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Arrays.asList(key1, key2));
+      replay();
+
+      PlatformMessage msg = buildRequest();
+
+      MessageBody response = handler.handleRequest(place, msg);
+      assertEquals("apikey:ListKeysResponse", response.getMessageType());
+
+      List<Map<String, Object>> keys = (List<Map<String, Object>>) response.getAttributes().get("keys");
+      assertNotNull(keys);
+      assertEquals(2, keys.size());
+
+      Map<String, Object> map1 = keys.get(0);
+      assertEquals(key1Id.toString(), map1.get("id"));
+      assertEquals("integration-1", map1.get("label"));
+      assertEquals("arcus_sk_0a1b2c3d", map1.get("keyPrefix"));
+      assertEquals(created1.getTime(), map1.get("created"));
+      assertNull(map1.get("lastUsed"));
+      assertNull(map1.get("expiresAt"));
+      assertEquals(false, map1.get("expired"));
+
+      Map<String, Object> map2 = keys.get(1);
+      assertEquals(key2Id.toString(), map2.get("id"));
+      assertEquals("integration-2", map2.get("label"));
+      assertEquals("arcus_sk_4e5f6a7b", map2.get("keyPrefix"));
+      assertEquals(created2.getTime(), map2.get("created"));
+      assertEquals(lastUsed.getTime(), map2.get("lastUsed"));
+      assertEquals(expiresAt.getTime(), map2.get("expiresAt"));
+      assertEquals(true, map2.get("expired"));
+   }
+
+   private PlatformMessage buildRequest() {
+      MessageBody body = MessageBody.buildMessage(ListApiKeysHandler.MESSAGE_TYPE, Collections.emptyMap());
+      return PlatformMessage.buildMessage(
+            body,
+            Address.clientAddress("test", "1"),
+            Address.fromString(place.getAddress()))
+            .create();
+   }
+}

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestRevokeApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestRevokeApiKeyHandler.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2019 Arcus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.iris.platform.services.apikey.handlers;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import com.google.inject.Inject;
+import com.iris.core.dao.AccountDAO;
+import com.iris.core.dao.ApiKeyDAO;
+import com.iris.core.messaging.memory.InMemoryMessageModule;
+import com.iris.core.messaging.memory.InMemoryPlatformMessageBus;
+import com.iris.messages.MessageBody;
+import com.iris.messages.PlatformMessage;
+import com.iris.messages.address.Address;
+import com.iris.messages.errors.ErrorEventException;
+import com.iris.messages.errors.Errors;
+import com.iris.messages.model.Account;
+import com.iris.messages.model.Place;
+import com.iris.security.apikey.ApiKey;
+import com.iris.security.authz.AuthzUtil;
+import com.iris.test.IrisMockTestCase;
+import com.iris.test.Mocks;
+import com.iris.test.Modules;
+
+@Mocks({ApiKeyDAO.class, AccountDAO.class})
+@Modules({InMemoryMessageModule.class})
+public class TestRevokeApiKeyHandler extends IrisMockTestCase {
+
+   @Inject ApiKeyDAO apiKeyDao;
+   @Inject AccountDAO accountDao;
+   @Inject InMemoryPlatformMessageBus messageBus;
+
+   private RevokeApiKeyHandler handler;
+   private Place place;
+   private Account account;
+   private UUID ownerId;
+
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      handler = new RevokeApiKeyHandler(apiKeyDao, accountDao, messageBus);
+
+      ownerId = UUID.randomUUID();
+
+      account = new Account();
+      account.setId(UUID.randomUUID());
+      account.setOwner(ownerId);
+
+      place = new Place();
+      place.setId(UUID.randomUUID());
+      place.setAccount(account.getId());
+      place.setName("Test Place");
+      place.setPopulation("general");
+   }
+
+   @Override
+   public void tearDown() throws Exception {
+      verify();
+      super.tearDown();
+   }
+
+   @Test
+   public void testRevokeSuccess() throws Exception {
+      UUID keyId = UUID.randomUUID();
+      ApiKey existing = createActiveKey(keyId);
+
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.singletonList(existing));
+      apiKeyDao.expire(EasyMock.eq(place.getId()), EasyMock.eq(keyId), EasyMock.eq("keyhash123"), EasyMock.isA(Date.class));
+      EasyMock.expectLastCall();
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, keyId.toString());
+      MessageBody response = handler.handleRequest(place, msg);
+
+      assertEquals("apikey:RevokeResponse", response.getMessageType());
+
+      // Verify broadcast event was sent
+      PlatformMessage event = messageBus.take();
+      assertNotNull(event);
+      assertEquals(RevokeApiKeyHandler.EVENT_API_KEY_REVOKED, event.getMessageType());
+      assertEquals(keyId.toString(), event.getValue().getAttributes().get("keyId"));
+   }
+
+   @Test
+   public void testRevokeMissingId() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, null);
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_MISSING_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testRevokeInvalidUuid() {
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, "not-a-uuid");
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testRevokeNotFound() {
+      UUID keyId = UUID.randomUUID();
+
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.emptyList());
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, keyId.toString());
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_NOT_FOUND, e.getCode());
+      }
+   }
+
+   @Test
+   public void testRevokeAlreadyRevoked() {
+      UUID keyId = UUID.randomUUID();
+      ApiKey existing = createExpiredKey(keyId);
+
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.singletonList(existing));
+      replay();
+
+      PlatformMessage msg = buildRequest(ownerId, keyId.toString());
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(Errors.CODE_INVALID_PARAM, e.getCode());
+      }
+   }
+
+   @Test
+   public void testRevokeNotOwner() {
+      UUID nonOwnerId = UUID.randomUUID();
+      EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
+      replay();
+
+      PlatformMessage msg = buildRequest(nonOwnerId, UUID.randomUUID().toString());
+
+      try {
+         handler.handleRequest(place, msg);
+         fail("Expected ErrorEventException");
+      } catch (ErrorEventException e) {
+         assertEquals(AuthzUtil.UNAUTHORIZED_CODE, e.getCode());
+      }
+   }
+
+   private ApiKey createActiveKey(UUID keyId) {
+      ApiKey key = new ApiKey();
+      key.setId(keyId);
+      key.setPlaceId(place.getId());
+      key.setLabel("test-key");
+      key.setKeyPrefix("arcus_sk_0a1b2c3d");
+      key.setKeyHash("keyhash123");
+      key.setCreated(new Date());
+      // no expiresAt = not expired
+      return key;
+   }
+
+   private ApiKey createExpiredKey(UUID keyId) {
+      ApiKey key = createActiveKey(keyId);
+      key.setExpiresAt(new Date(System.currentTimeMillis() - 86400000L)); // expired yesterday
+      return key;
+   }
+
+   private PlatformMessage buildRequest(UUID actorId, String keyId) {
+      Map<String, Object> attrs = new HashMap<>();
+      if (keyId != null) {
+         attrs.put("id", keyId);
+      }
+
+      MessageBody body = MessageBody.buildMessage(RevokeApiKeyHandler.MESSAGE_TYPE, attrs);
+      return PlatformMessage.buildMessage(
+            body,
+            Address.clientAddress("test", "1"),
+            Address.fromString(place.getAddress()))
+            .withActor(Address.platformService(actorId, "person"))
+            .create();
+   }
+}


### PR DESCRIPTION
Adds the Delete operation back to the API key service (previously partially implemented and reverted in 1a2a9100) with proper service XML registration, and adds comprehensive unit tests for all four API key management handlers (Create, List, Revoke, Delete) covering success paths, validation, authorization, and edge cases.