### PR TITLE
Bump platform and khakis to 2026.3.1

### DIFF
--- a/khakis/version.properties
+++ b/khakis/version.properties
@@ -1,4 +1,4 @@
 major=2026
 minor=3
-patch=0
+patch=1
 qualifier=

--- a/platform/version.properties
+++ b/platform/version.properties
@@ -1,4 +1,4 @@
 major=2026
 minor=3
-patch=0
+patch=1
 qualifier=


### PR DESCRIPTION
## Summary
- Bump `platform/version.properties` patch version from 0 to 1 (2026.3.0 → 2026.3.1)
- Bump `khakis/version.properties` patch version from 0 to 1 (2026.3.0 → 2026.3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)