### PR TITLE
Fix rule unit test failures during DST transitions

### DIFF
--- a/platform/arcus-rules/src/test/java/com/iris/common/rule/RuleFixtures.java
+++ b/platform/arcus-rules/src/test/java/com/iris/common/rule/RuleFixtures.java
@@ -20,6 +20,7 @@ package com.iris.common.rule;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.junit.Assert;
 
@@ -40,10 +41,11 @@ public class RuleFixtures {
     * @return
     */
    public static Calendar time(int hours, int minutes, int seconds) {
-      Calendar calendar = Calendar.getInstance();
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
       calendar.set(Calendar.HOUR_OF_DAY, hours);
       calendar.set(Calendar.MINUTE, minutes);
       calendar.set(Calendar.SECOND, seconds);
+      calendar.set(Calendar.MILLISECOND, 0);
       return calendar;
    }
 
@@ -53,7 +55,7 @@ public class RuleFixtures {
     * @return
     */
    public static Calendar day(int dayOfWeek) {
-      Calendar calendar = Calendar.getInstance();
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
       calendar.set(Calendar.DAY_OF_WEEK, dayOfWeek);
       return calendar;
    }


### PR DESCRIPTION
## Summary
- Use UTC timezone in `RuleFixtures.time()` and `RuleFixtures.day()` test helpers instead of the system default timezone, preventing `Calendar`-based time calculations from being affected by DST transitions
- Zero out milliseconds field for deterministic comparisons

The root cause was that `Calendar.getInstance()` uses the system default timezone. When tests run on a day with a DST transition, two calls to `time(9, 0, 0)` at slightly different moments could produce calendars with different UTC offsets, causing a ~1 hour discrepancy in millisecond comparisons.

Fixes #135

## Test plan
- [x] `TestTimeOfDayTrigger` — all 3 tests pass
- [x] `TestTimeOfDayFilter` — all 7 tests pass
- [x] `TestInactiveForTimePeriod` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)