### PR TITLE
Fix ApiKey test compilation after Cassandra 4.x migration

### DIFF
--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestCreateApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestCreateApiKeyHandler.java
@@ -17,7 +17,6 @@ package com.iris.platform.services.apikey.handlers;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -128,7 +127,7 @@ public class TestCreateApiKeyHandler extends IrisMockTestCase {
 
       ApiKey captured = savedKey.getValue();
       assertNotNull(captured.getExpiresAt());
-      assertEquals(futureTime, captured.getExpiresAt().getTime());
+      assertEquals(futureTime, captured.getExpiresAt().toEpochMilli());
    }
 
    @Test

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestDeleteApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestDeleteApiKeyHandler.java
@@ -15,8 +15,8 @@
  */
 package com.iris.platform.services.apikey.handlers;
 
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -169,14 +169,14 @@ public class TestDeleteApiKeyHandler extends IrisMockTestCase {
       key.setLabel("test-key");
       key.setKeyPrefix("arcus_sk_0a1b2c3d");
       key.setKeyHash("keyhash123");
-      key.setCreated(new Date());
+      key.setCreated(Instant.now());
       // no expiresAt = not expired
       return key;
    }
 
    private ApiKey createExpiredKey(UUID keyId) {
       ApiKey key = createActiveKey(keyId);
-      key.setExpiresAt(new Date(System.currentTimeMillis() - 86400000L)); // expired yesterday
+      key.setExpiresAt(Instant.ofEpochMilli(System.currentTimeMillis() - 86400000L)); // expired yesterday
       return key;
    }
 

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestListApiKeysHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestListApiKeysHandler.java
@@ -15,9 +15,9 @@
  */
 package com.iris.platform.services.apikey.handlers;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -86,10 +86,10 @@ public class TestListApiKeysHandler extends IrisMockTestCase {
    public void testListMultipleKeys() {
       UUID key1Id = UUID.randomUUID();
       UUID key2Id = UUID.randomUUID();
-      Date created1 = new Date(1700000000000L);
-      Date created2 = new Date(1700100000000L);
-      Date lastUsed = new Date(1700200000000L);
-      Date expiresAt = new Date(1600000000000L); // in the past = expired
+      Instant created1 = Instant.ofEpochMilli(1700000000000L);
+      Instant created2 = Instant.ofEpochMilli(1700100000000L);
+      Instant lastUsed = Instant.ofEpochMilli(1700200000000L);
+      Instant expiresAt = Instant.ofEpochMilli(1600000000000L); // in the past = expired
 
       ApiKey key1 = new ApiKey();
       key1.setId(key1Id);
@@ -127,7 +127,7 @@ public class TestListApiKeysHandler extends IrisMockTestCase {
       assertEquals(key1Id.toString(), map1.get("id"));
       assertEquals("integration-1", map1.get("label"));
       assertEquals("arcus_sk_0a1b2c3d", map1.get("keyPrefix"));
-      assertEquals(created1.getTime(), map1.get("created"));
+      assertEquals(created1.toEpochMilli(), map1.get("created"));
       assertNull(map1.get("lastUsed"));
       assertNull(map1.get("expiresAt"));
       assertEquals(false, map1.get("expired"));
@@ -136,9 +136,9 @@ public class TestListApiKeysHandler extends IrisMockTestCase {
       assertEquals(key2Id.toString(), map2.get("id"));
       assertEquals("integration-2", map2.get("label"));
       assertEquals("arcus_sk_4e5f6a7b", map2.get("keyPrefix"));
-      assertEquals(created2.getTime(), map2.get("created"));
-      assertEquals(lastUsed.getTime(), map2.get("lastUsed"));
-      assertEquals(expiresAt.getTime(), map2.get("expiresAt"));
+      assertEquals(created2.toEpochMilli(), map2.get("created"));
+      assertEquals(lastUsed.toEpochMilli(), map2.get("lastUsed"));
+      assertEquals(expiresAt.toEpochMilli(), map2.get("expiresAt"));
       assertEquals(true, map2.get("expired"));
    }
 

--- a/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestRevokeApiKeyHandler.java
+++ b/platform/arcus-containers/platform-services/src/test/java/com/iris/platform/services/apikey/handlers/TestRevokeApiKeyHandler.java
@@ -15,8 +15,8 @@
  */
 package com.iris.platform.services.apikey.handlers;
 
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -86,7 +86,7 @@ public class TestRevokeApiKeyHandler extends IrisMockTestCase {
 
       EasyMock.expect(accountDao.findById(account.getId())).andReturn(account);
       EasyMock.expect(apiKeyDao.findByPlace(place.getId())).andReturn(Collections.singletonList(existing));
-      apiKeyDao.expire(EasyMock.eq(place.getId()), EasyMock.eq(keyId), EasyMock.eq("keyhash123"), EasyMock.isA(Date.class));
+      apiKeyDao.expire(EasyMock.eq(place.getId()), EasyMock.eq(keyId), EasyMock.eq("keyhash123"), EasyMock.isA(Instant.class));
       EasyMock.expectLastCall();
       replay();
 
@@ -192,14 +192,14 @@ public class TestRevokeApiKeyHandler extends IrisMockTestCase {
       key.setLabel("test-key");
       key.setKeyPrefix("arcus_sk_0a1b2c3d");
       key.setKeyHash("keyhash123");
-      key.setCreated(new Date());
+      key.setCreated(Instant.now());
       // no expiresAt = not expired
       return key;
    }
 
    private ApiKey createExpiredKey(UUID keyId) {
       ApiKey key = createActiveKey(keyId);
-      key.setExpiresAt(new Date(System.currentTimeMillis() - 86400000L)); // expired yesterday
+      key.setExpiresAt(Instant.ofEpochMilli(System.currentTimeMillis() - 86400000L)); // expired yesterday
       return key;
    }
 


### PR DESCRIPTION
## Summary
- Update 4 ApiKey test files to use `java.time.Instant` instead of `java.util.Date`, matching the ApiKey model changes from the Cassandra driver 4.x upgrade (PR #295)
- Fixes `compileTestJava` failure in `:platform:arcus-containers:platform-services` (10 compile errors)

## Test plan
- [x] Verified `compileTestJava` passes locally with JDK 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)