### PR TITLE
Fix Cassandra 4.x Date codec errors in scheduler and subsystem DAOs

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraSchedulerModelDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/scheduler/cassandra/CassandraSchedulerModelDao.java
@@ -438,7 +438,7 @@ public class CassandraSchedulerModelDao extends BaseModelDao implements Schedule
                .update(SchedulerTable.NAME)
                .addColumn(Columns.MODIFIED)
                ;
-      values.add(timestamp);
+      values.add(timestamp.toInstant());
 
       attributes.forEach((attribute) -> {
          builder.addColumn(Columns.ATTRIBUTES + "[?]");
@@ -508,8 +508,8 @@ public class CassandraSchedulerModelDao extends BaseModelDao implements Schedule
    ) {
       ResultSet rs = session().execute(
             insert.bind(
-               model.getCreated(),
-               model.getModified(),
+               model.getCreated().toInstant(),
+               model.getModified().toInstant(),
                encode( model.toMap() ),
                placeId,
                SchedulerModel.getTarget(model),

--- a/platform/arcus-lib/src/main/java/com/iris/platform/subsystem/cassandra/CassandraSubsystemDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/subsystem/cassandra/CassandraSubsystemDao.java
@@ -266,7 +266,7 @@ public class CassandraSubsystemDao extends BaseModelDao implements SubsystemDao 
                .addColumn(Columns.MODIFIED)
                .usePreparedStatementCache()
                ;
-      values.add(timestamp);
+      values.add(timestamp.toInstant());
 
       attributes.forEach((attribute) -> {
          builder.addColumn(Columns.ATTRIBUTES + "[?]");


### PR DESCRIPTION
## Summary
- Fix `CodecNotFoundException: TIMESTAMP <-> java.util.Date` in `CassandraSchedulerModelDao.insertModel()` and `updateAttributes()` — triggered by `scheduler:GetScheduler` via `findOrCreateByTarget`
- Fix same issue in `CassandraSubsystemDao.updateAttributes()` — would affect any subsystem attribute update
- Cassandra Driver 4.x requires `java.time.Instant` for TIMESTAMP columns; these three call sites were still passing `java.util.Date`

## Test plan
- [x] Verify `scheduler:GetScheduler` no longer throws codec error
- [x] Verify subsystem attribute updates (e.g. security arm/disarm) work without error
- [x] Run `./gradlew :platform:arcus-lib:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)