### PR TITLE
Fix ZooKeeper cluster service bugs and improve robustness

### DIFF
--- a/platform/arcus-lib/src/main/java/com/iris/platform/cluster/ClusterService.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/cluster/ClusterService.java
@@ -37,6 +37,7 @@ import com.iris.core.StartupListener;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.iris.core.dao.cassandra.CassandraHealth;
 import com.iris.platform.cluster.exception.ClusterIdLostException;
+import com.iris.platform.cluster.zookeeper.ZookeeperClusterServiceDao;
 
 /**
  * 
@@ -75,6 +76,19 @@ public class ClusterService implements StartupListener {
       this.retryDelayMs = config.getRegistrationRetryDelay(TimeUnit.MILLISECONDS);
       this.retries = config.getRegistrationRetries();
       this.exitOnDeregistered = config.isExitOnDeregistered();
+
+      if (clusterServiceDao instanceof ZookeeperClusterServiceDao) {
+         ZookeeperClusterServiceDao zkDao = (ZookeeperClusterServiceDao) clusterServiceDao;
+         zkDao.setOnSessionExpired(this::onDeregistered);
+         zkDao.setOnReconnected(() -> {
+            ClusterServiceRecord record = recordRef.get();
+            if (record != null && !zkDao.verifyRegistration(record)) {
+               logger.warn("Ephemeral node lost after zookeeper reconnect, re-registering");
+               onDeregistered();
+               tryRegister(0);
+            }
+         });
+      }
    }
 
    @Override
@@ -177,8 +191,7 @@ public class ClusterService implements StartupListener {
          }
          
          if(exitOnDeregistered) {
-            logger.error("SHUTTING DOWN -- Lost cluster service id and exitOnDeregister is true");
-            System.err.println("SHUTTING DOWN -- Lost cluster service id and exitOnDeregister is true");
+            logger.error("SHUTTING DOWN -- Lost cluster service id and exitOnDeregistered is true");
             System.exit(-1);
          }
       }

--- a/platform/arcus-lib/src/main/java/com/iris/platform/cluster/zookeeper/ZookeeperClusterServiceDao.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/cluster/zookeeper/ZookeeperClusterServiceDao.java
@@ -34,158 +34,255 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ZookeeperClusterServiceDao implements ClusterServiceDao, Watcher {
-    private static final Logger logger = LoggerFactory.getLogger(ZookeeperClusterServiceDao.class);
+   private static final Logger logger = LoggerFactory.getLogger(ZookeeperClusterServiceDao.class);
+   private static final long CONNECTION_TIMEOUT_SEC = 30;
 
-    private final Clock clock;
-    private final ZooKeeper zk;
-    private final ZookeeperMonitor monitor;
-    private final String service;
-    private final int members;
-    private final String host;
-    private final String zkPathPrefix;
+   private final Clock clock;
+   private final ZookeeperMonitor monitor;
+   private final String service;
+   private final int members;
+   private final String host;
+   private final String zkPathPrefix;
+   private final String zkConnectString;
+   private final int zkSessionTimeout;
+   private final Gson gson;
 
-    private final Gson gson;
+   private volatile ZooKeeper zk;
 
-    @Inject
-    public ZookeeperClusterServiceDao(
-            Clock clock,
-            PartitionConfig config,
-            ClusterConfig clusterConfig,
-            @Named(IrisApplicationModule.NAME_APPLICATION_NAME) String service) throws IOException {
-        this.clock = clock;
-        this.zk = new ZooKeeper(clusterConfig.getClusterZkHost(), clusterConfig.getClusterZkTimeout(), this);
-        this.members = config.getMembers();
-        this.host = IrisApplicationInfo.getHostName();
-        this.service = service;
-        this.gson = new Gson();
-        this.monitor = new ZookeeperMonitor(zk);
+   @Inject
+   public ZookeeperClusterServiceDao(
+         Clock clock,
+         PartitionConfig config,
+         ClusterConfig clusterConfig,
+         @Named(IrisApplicationModule.NAME_APPLICATION_NAME) String service) throws IOException {
+      this.clock = clock;
+      this.members = config.getMembers();
+      this.host = IrisApplicationInfo.getHostName();
+      this.service = service;
+      this.gson = new Gson();
+      this.monitor = new ZookeeperMonitor();
+      this.zkPathPrefix = clusterConfig.getClusterZkPathPrefix();
+      this.zkConnectString = clusterConfig.getClusterZkHost();
+      this.zkSessionTimeout = clusterConfig.getClusterZkTimeout();
+      this.zk = new ZooKeeper(zkConnectString, zkSessionTimeout, this);
+   }
 
-        this.zkPathPrefix = clusterConfig.getClusterZkPathPrefix();
-    }
+   public void setOnSessionExpired(Runnable onSessionExpired) {
+      monitor.setOnSessionExpired(() -> {
+         onSessionExpired.run();
+         reconnect();
+      });
+   }
 
-    @Override
-    public ClusterServiceRecord register() throws ClusterIdUnavailableException {
-        List<Integer> others =
-                listMembersByService(service)
-                        .stream()
-                        .sorted(Comparator.comparing(ClusterServiceRecord::getLastHeartbeat))
-                        .map(ClusterServiceRecord::getMemberId)
-                        .collect(Collectors.toList());
-        try (Timer.Context timer = ZookeeperClusterServiceDao.ClusterServiceMetrics.registerTimer.time()) {
-            Instant heartbeat = clock.instant();
-            // grab an empty cluster id, or wait
-            for (int i = 0; i < members; i++) {
-                if (others.contains(i)) {
-                    continue;
-                }
+   public void setOnReconnected(Runnable onReconnected) {
+      monitor.setOnReconnected(onReconnected);
+   }
 
-                int memberId = i;
-                ClusterServiceRecord csr = tryInsert(memberId, heartbeat);
-                if (csr != null) {
-                    return csr;
-                } else {
-                    ZookeeperClusterServiceDao.ClusterServiceMetrics.clusterRegistrationMissCounter.inc();
-                }
+   @Override
+   public ClusterServiceRecord register() throws ClusterIdUnavailableException {
+      try {
+         if (!monitor.awaitConnection(CONNECTION_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+            throw new ClusterIdUnavailableException("Timed out waiting for zookeeper connection");
+         }
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         throw new ClusterIdUnavailableException("Interrupted waiting for zookeeper connection");
+      }
+
+      List<Integer> others =
+            listMembersByService(service)
+                  .stream()
+                  .sorted(Comparator.comparing(ClusterServiceRecord::getLastHeartbeat))
+                  .map(ClusterServiceRecord::getMemberId)
+                  .collect(Collectors.toList());
+      try (Timer.Context timer = ClusterServiceMetrics.registerTimer.time()) {
+         Instant heartbeat = clock.instant();
+         for (int i = 0; i < members; i++) {
+            if (others.contains(i)) {
+               continue;
             }
 
-            ZookeeperClusterServiceDao.ClusterServiceMetrics.clusterRegistrationFailedCounter.inc();
-            throw new ClusterIdUnavailableException("No cluster ids for service [" + service + "] were available");
-        }
-    }
-
-    private ClusterServiceRecord tryInsert(int memberId, Instant heartbeat) {
-        ClusterServiceRecord csr = new ClusterServiceRecord();
-        csr.setHost(host);
-        csr.setRegistered(heartbeat);
-        csr.setLastHeartbeat(heartbeat);
-        csr.setService(service);
-        csr.setMemberId(memberId);
-
-        try {
-            zk.create(zkPathPrefix + service + '/' + memberId, gson.toJson(csr).getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-            return csr;
-        } catch (KeeperException e) {
-            logger.info("Creating path in zookeeper for {} ", service);
-            if (e.code() == KeeperException.Code.NONODE) {
-                try {
-                    zk.create(zkPathPrefix + service, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                } catch(KeeperException | InterruptedException e1) {
-                    logger.error("Failed to create path for service", e1);
-                    return null;
-                }
-            }
-        } catch (InterruptedException e) {
-            logger.error("Failed to write to zk", e);
-            return null;
-        }
-        return null;
-    }
-
-    @Override
-    public ClusterServiceRecord heartbeat(ClusterServiceRecord service) throws ClusterServiceDaoException {
-        // Not required for this implementation - ZooKeeper will automatically expire ephemeral nodes.
-        return null;
-    }
-
-    @Override
-    public boolean deregister(ClusterServiceRecord record) {
-        return false;
-    }
-
-    @Override
-    public List<ClusterServiceRecord> listMembersByService(String service) {
-        List<ClusterServiceRecord> records = new ArrayList<ClusterServiceRecord>();
-        try(Timer.Context timer = ZookeeperClusterServiceDao.ClusterServiceMetrics.listByServiceTimer.time()) {
-            List<String> children = zk.getChildren(zkPathPrefix + service, false);
-
-            for (String child: children) {
-                ClusterServiceRecord record = transform(zk.getData(zkPathPrefix + service + '/' + child, false, null));
-                if (record != null) {
-                    records.add(record);
-                }
-            }
-        } catch (InterruptedException e) {
-            // ignore
-        } catch (KeeperException e) {
-            if (e.code() == KeeperException.Code.NONODE) {
-                logger.info("{} hasn't been registered in zookeeper before, will need to be created", service);
+            ClusterServiceRecord csr = tryInsert(i, heartbeat);
+            if (csr != null) {
+               return csr;
             } else {
-                logger.warn("Failed to list members of service", e);
+               ClusterServiceMetrics.clusterRegistrationMissCounter.inc();
             }
-            if (e.code() == KeeperException.Code.CONNECTIONLOSS) {
-                logger.info("Unable to communicate with zookeeper {}", e.getMessage());
+         }
+
+         ClusterServiceMetrics.clusterRegistrationFailedCounter.inc();
+         throw new ClusterIdUnavailableException("No cluster ids for service [" + service + "] were available");
+      }
+   }
+
+   private ClusterServiceRecord tryInsert(int memberId, Instant heartbeat) {
+      ClusterServiceRecord csr = new ClusterServiceRecord();
+      csr.setHost(host);
+      csr.setRegistered(heartbeat);
+      csr.setLastHeartbeat(heartbeat);
+      csr.setService(service);
+      csr.setMemberId(memberId);
+
+      String path = zkPathPrefix + service + '/' + memberId;
+      byte[] data = gson.toJson(csr).getBytes(StandardCharsets.UTF_8);
+
+      try {
+         zk.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+         return csr;
+      } catch (KeeperException e) {
+         if (e.code() == KeeperException.Code.NONODE) {
+            try {
+               logger.info("Creating path in zookeeper for {}", service);
+               zk.create(zkPathPrefix + service, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } catch (KeeperException e1) {
+               if (e1.code() != KeeperException.Code.NODEEXISTS) {
+                  logger.error("Failed to create path for service", e1);
+                  return null;
+               }
+            } catch (InterruptedException e1) {
+               Thread.currentThread().interrupt();
+               logger.error("Failed to create path for service", e1);
+               return null;
             }
-        }
+            // Retry the ephemeral node creation now that the parent exists
+            try {
+               zk.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+               return csr;
+            } catch (KeeperException | InterruptedException e1) {
+               logger.error("Failed to create ephemeral node on retry", e1);
+               return null;
+            }
+         } else if (e.code() == KeeperException.Code.NODEEXISTS) {
+            return null;
+         }
+         logger.error("Failed to write to zk", e);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         logger.error("Failed to write to zk", e);
+      }
+      return null;
+   }
 
-        return records;
-    }
+   @Override
+   public ClusterServiceRecord heartbeat(ClusterServiceRecord service) throws ClusterServiceDaoException {
+      // Not required for this implementation - ZooKeeper will automatically expire ephemeral nodes.
+      return service;
+   }
 
-    private ClusterServiceRecord transform(byte[] zkdata) {
-        ClusterServiceRecord record = gson.fromJson(new String(zkdata), ClusterServiceRecord.class);
-        return record;
-    }
+   @Override
+   public boolean deregister(ClusterServiceRecord record) {
+      try (Timer.Context timer = ClusterServiceMetrics.deregisterTimer.time()) {
+         String path = zkPathPrefix + record.getService() + '/' + record.getMemberId();
+         zk.delete(path, -1);
+         return true;
+      } catch (KeeperException e) {
+         if (e.code() == KeeperException.Code.NONODE) {
+            return true;
+         }
+         logger.warn("Failed to deregister from zookeeper", e);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         logger.warn("Interrupted while deregistering from zookeeper", e);
+      }
+      return false;
+   }
 
-    @Override
-    public void process(WatchedEvent event) {
-        monitor.process(event);
-    }
+   @Override
+   public List<ClusterServiceRecord> listMembersByService(String service) {
+      List<ClusterServiceRecord> records = new ArrayList<>();
+      try (Timer.Context timer = ClusterServiceMetrics.listByServiceTimer.time()) {
+         List<String> children = zk.getChildren(zkPathPrefix + service, false);
 
-    private static class ClusterServiceMetrics {
-        static final Timer registerTimer = DaoMetrics.upsertTimer(ClusterServiceDao.class, "register");
-        static final Timer deregisterTimer = DaoMetrics.deleteTimer(ClusterServiceDao.class, "deregister");
-        static final Timer listByServiceTimer = DaoMetrics.readTimer(ClusterServiceDao.class, "listMembersByService");
-        static final Counter clusterIdRegisteredCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterid.registered");
-        static final Counter clusterIdLostCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterid.lost");
-        static final Counter clusterRegistrationMissCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterregistration.collision");
-        static final Counter clusterRegistrationFailedCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterregistration.failed");
-    }
+         for (String child : children) {
+            try {
+               ClusterServiceRecord record = transform(zk.getData(zkPathPrefix + service + '/' + child, false, null));
+               if (record != null) {
+                  records.add(record);
+               }
+            } catch (KeeperException e) {
+               if (e.code() == KeeperException.Code.NONODE) {
+                  logger.debug("Ephemeral node {} disappeared while listing members", child);
+               } else {
+                  logger.warn("Failed to read data for member {}", child, e);
+               }
+            }
+         }
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+      } catch (KeeperException e) {
+         if (e.code() == KeeperException.Code.NONODE) {
+            logger.info("{} hasn't been registered in zookeeper before, will need to be created", service);
+         } else if (e.code() == KeeperException.Code.CONNECTIONLOSS) {
+            logger.warn("Unable to communicate with zookeeper: {}", e.getMessage());
+         } else {
+            logger.warn("Failed to list members of service", e);
+         }
+      }
+
+      return records;
+   }
+
+   public boolean verifyRegistration(ClusterServiceRecord record) {
+      if (record == null) {
+         return false;
+      }
+      String path = zkPathPrefix + record.getService() + '/' + record.getMemberId();
+      try {
+         return zk.exists(path, false) != null;
+      } catch (KeeperException | InterruptedException e) {
+         if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+         }
+         logger.warn("Failed to verify registration at {}", path, e);
+         return false;
+      }
+   }
+
+   private void reconnect() {
+      try {
+         ZooKeeper oldZk = this.zk;
+         if (oldZk != null) {
+            try {
+               oldZk.close();
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+               logger.warn("Interrupted while closing expired zookeeper session", e);
+            }
+         }
+         monitor.resetConnectionLatch();
+         this.zk = new ZooKeeper(zkConnectString, zkSessionTimeout, this);
+         logger.info("Created new zookeeper session after expiry");
+      } catch (IOException e) {
+         logger.error("Failed to create new zookeeper connection", e);
+      }
+   }
+
+   private ClusterServiceRecord transform(byte[] zkdata) {
+      return gson.fromJson(new String(zkdata, StandardCharsets.UTF_8), ClusterServiceRecord.class);
+   }
+
+   @Override
+   public void process(WatchedEvent event) {
+      monitor.process(event);
+   }
+
+   private static class ClusterServiceMetrics {
+      static final Timer registerTimer = DaoMetrics.upsertTimer(ClusterServiceDao.class, "register");
+      static final Timer deregisterTimer = DaoMetrics.deleteTimer(ClusterServiceDao.class, "deregister");
+      static final Timer listByServiceTimer = DaoMetrics.readTimer(ClusterServiceDao.class, "listMembersByService");
+      static final Counter clusterIdRegisteredCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterid.registered");
+      static final Counter clusterIdLostCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterid.lost");
+      static final Counter clusterRegistrationMissCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterregistration.collision");
+      static final Counter clusterRegistrationFailedCounter = DaoMetrics.counter(ClusterServiceDao.class, "clusterregistration.failed");
+   }
 }

--- a/platform/arcus-lib/src/main/java/com/iris/platform/cluster/zookeeper/ZookeeperMonitor.java
+++ b/platform/arcus-lib/src/main/java/com/iris/platform/cluster/zookeeper/ZookeeperMonitor.java
@@ -17,40 +17,85 @@ package com.iris.platform.cluster.zookeeper;
 
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.AsyncCallback.StatCallback;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 public class ZookeeperMonitor implements Watcher, StatCallback {
-    private static final Logger logger = LoggerFactory.getLogger(ZookeeperMonitor.class);
+   private static final Logger logger = LoggerFactory.getLogger(ZookeeperMonitor.class);
 
-    private final ZooKeeper zk;
+   private volatile Runnable onSessionExpired;
+   private volatile Runnable onReconnected;
+   private volatile CountDownLatch connectedLatch = new CountDownLatch(1);
+   private volatile boolean connected;
 
-    public ZookeeperMonitor(ZooKeeper zk) {
-        this.zk = zk;
-    }
+   public ZookeeperMonitor() {
+   }
 
-    @Override
-    public void process(WatchedEvent event) {
-        if (event.getType() == Event.EventType.None) {
-            switch (event.getState()) {
-                case SyncConnected:
-                    break;
-                case Expired:
-                    // TODO: move this elsewhere?
-                    logger.error("SHUTTING DOWN -- zookeeper session has been marked as expired");
-                    System.err.println("SHUTTING DOWN -- zookeeper session has been marked as expired");
-                    System.exit(-1);
+   public void setOnSessionExpired(Runnable onSessionExpired) {
+      this.onSessionExpired = onSessionExpired;
+   }
 
-                    break;
-            }
-        } else {
+   public void setOnReconnected(Runnable onReconnected) {
+      this.onReconnected = onReconnected;
+   }
 
-        }
-    }
+   public boolean isConnected() {
+      return connected;
+   }
 
-    public void processResult(int rc, String path, Object ctx, Stat stat) {
-    }
+   public boolean awaitConnection(long timeout, TimeUnit unit) throws InterruptedException {
+      return connectedLatch.await(timeout, unit);
+   }
+
+   public void resetConnectionLatch() {
+      connectedLatch = new CountDownLatch(1);
+      connected = false;
+   }
+
+   @Override
+   public void process(WatchedEvent event) {
+      if (event.getType() == Event.EventType.None) {
+         switch (event.getState()) {
+            case SyncConnected:
+               logger.info("Connected to zookeeper");
+               boolean wasDisconnected = !connected;
+               connected = true;
+               connectedLatch.countDown();
+               if (wasDisconnected) {
+                  Runnable handler = onReconnected;
+                  if (handler != null) {
+                     handler.run();
+                  }
+               }
+               break;
+            case Disconnected:
+               logger.warn("Disconnected from zookeeper, waiting for reconnect");
+               connected = false;
+               break;
+            case Expired:
+               logger.error("Zookeeper session expired, all ephemeral nodes lost");
+               connected = false;
+               Runnable handler = onSessionExpired;
+               if (handler != null) {
+                  handler.run();
+               } else {
+                  logger.error("No session expiry handler registered, forcing shutdown");
+                  System.exit(-1);
+               }
+               break;
+            default:
+               logger.warn("Unhandled zookeeper state: {}", event.getState());
+               break;
+         }
+      }
+   }
+
+   @Override
+   public void processResult(int rc, String path, Object ctx, Stat stat) {
+   }
 }


### PR DESCRIPTION
The Zookeeper cluster manager was originally a prototype intended to quickly replace the brittle cassandra cluster manager and had a number of outstanding issues. Most of these didn't really matter since the service would just restart, but this gives a little more chance of recovery before it is killed via container orchestration.

- Fix tryInsert not retrying after creating parent znode (slot 0 always wasted)
- Fix heartbeat() returning null causing NPE in ClusterService
- Implement deregister() to delete ephemeral node on graceful shutdown
- Restore interrupt flag on caught InterruptedExceptions
- Handle NONODE per-child in listMembersByService (race with ephemeral expiry)
- Wait for ZK connection before registering (CountDownLatch)
- Track connection state and verify registration on reconnect after disconnect
- Recreate ZK client after session expiry to allow re-registration
- Route session expiry through ClusterService.onDeregistered for graceful shutdown
- Remove System.err.println in favor of SLF4J