### PR TITLE
Fix flaky TestDeviceServiceLost by using blocking poll

### DIFF
--- a/platform/arcus-containers/driver-services/src/test/java/com/iris/driver/service/TestDeviceServiceLost.java
+++ b/platform/arcus-containers/driver-services/src/test/java/com/iris/driver/service/TestDeviceServiceLost.java
@@ -16,6 +16,7 @@
 package com.iris.driver.service;
 
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -152,21 +153,21 @@ public class TestDeviceServiceLost extends IrisMockTestCase {
       EasyMock.expectLastCall();
    }
    
-   private void assertForceRemove() {
-      PlatformMessage message = messages.poll();
+   private void assertForceRemove() throws Exception {
+      PlatformMessage message = messages.take();
       assertEquals(DeviceCapability.ForceRemoveRequest.NAME, message.getMessageType());
    }
-   
-   private void assertValueChange(Map<String,Object> attributes) {
-      PlatformMessage message = messages.poll();
+
+   private void assertValueChange(Map<String,Object> attributes) throws Exception {
+      PlatformMessage message = messages.take();
       assertEquals(Address.broadcastAddress(), message.getDestination());
       assertEquals(device.getAddress(), message.getSource().getRepresentation());
       assertEquals(Capability.EVENT_VALUE_CHANGE, message.getMessageType());
       assertEquals(attributes, message.getValue().getAttributes());
    }
 
-   private void assertDeleted() {
-      PlatformMessage message = messages.poll();
+   private void assertDeleted() throws Exception {
+      PlatformMessage message = messages.take();
       assertEquals(Address.broadcastAddress(), message.getDestination());
       assertEquals(device.getAddress(), message.getSource().getRepresentation());
       assertEquals(Capability.EVENT_DELETED, message.getMessageType());


### PR DESCRIPTION
Fixes a frequently flaky test in `TestDeviceServiceLost > testLostTombstonedDevice`.

The assert helpers used messages.poll() which is non-blocking and returns null if the message hasn't been enqueued yet, causing intermittent failures. Switch to messages.take() which blocks for the message to arrive.