### PR TITLE
Speed up CI: upgrade actions, enable parallel builds and test execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
       - name: Run tests
-        run: ./gradlew clean test -x spotbugsMain -x spotbugsTest -x spotbugsJmh --no-daemon
+        run: ./gradlew test -x spotbugsMain -x spotbugsTest -x spotbugsJmh --no-daemon --parallel --build-cache
 
   build-and-push-image:
     needs: tests
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build jars
-        run: ./gradlew clean jar --no-daemon
+        run: ./gradlew jar --no-daemon --parallel --build-cache
 
       - name: Build and push containers
         run: bash khakis/bin/release.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,29 +13,29 @@ jobs:
         java-version: ['8', '11']
     name: Test (JDK ${{ matrix.java-version }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
            java-version: ${{ matrix.java-version }}
            distribution: 'corretto'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - name: run tests
-        run: ./gradlew test --no-daemon
+        uses: gradle/gradle-build-action@v3
+      - name: Run tests
+        run: ./gradlew test --no-daemon --parallel --build-cache
 
   Driver-Cucumber-Tests:
     runs-on: ubuntu-latest
     name: Driver Cucumber Tests
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'corretto'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
       - name: Run driver cucumber tests
-        run: ./gradlew :platform:arcus-platform-drivers:driver-tests:cucumber --no-daemon
+        run: ./gradlew :platform:arcus-platform-drivers:driver-tests:cucumber --no-daemon --parallel --build-cache

--- a/gradle/subproject.gradle
+++ b/gradle/subproject.gradle
@@ -126,6 +126,7 @@ test {
     testLogging {
         events "STARTED", "PASSED", "FAILED", "SKIPPED"
     }
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 if ("${use_jacoco}" == "true") {


### PR DESCRIPTION
- Upgrade checkout, setup-java, and gradle-build-action to latest versions
- Add --parallel and --build-cache flags to all Gradle commands
- Remove unnecessary clean steps in release workflow
- Enable parallel test execution via maxParallelForks