### PR TITLE
Bump release version to 2026.3.2

### DIFF
--- a/agent/gradle.properties
+++ b/agent/gradle.properties
@@ -8,7 +8,7 @@ iris_common_changing=false
 
 version_major=2
 version_minor=13
-version_patch=26
+version_patch=27
 version_prerelease=-SNAPSHOT
 
 org.gradle.configureondemand=true

--- a/khakis/version.properties
+++ b/khakis/version.properties
@@ -1,4 +1,4 @@
 major=2026
 minor=3
-patch=1
+patch=2
 qualifier=

--- a/platform/version.properties
+++ b/platform/version.properties
@@ -1,4 +1,4 @@
 major=2026
 minor=3
-patch=1
+patch=2
 qualifier=


### PR DESCRIPTION
## Summary
- Bump platform and khakis version from 2026.3.1 → 2026.3.2
- Bump agent version from 2.13.26 → 2.13.27

## Test plan
- [x] Verify platform builds with updated version
- [x] Verify khakis containers build with updated version
- [x] Verify agent builds with updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)