### PR TITLE
Fix flaky scheduler tests by running initial partition scheduling synchronously

### DIFF
--- a/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformEventSchedulerService.java
+++ b/platform/arcus-containers/scheduler-service/src/main/java/com/iris/service/scheduler/PlatformEventSchedulerService.java
@@ -144,9 +144,10 @@ public class PlatformEventSchedulerService implements EventSchedulerService, Par
       
       for(PartitionOffset offset: offsets.values()) {
          PartitionSchedulerJob job = new PartitionSchedulerJob(offset);
+         job.schedule();
          Future<?> future = executor.scheduleAtFixedRate(
                () -> job.schedule(),
-               0,
+               scheduleDao.getTimeBucketDurationMs(),
                scheduleDao.getTimeBucketDurationMs(),
                TimeUnit.MILLISECONDS
          );

--- a/platform/arcus-containers/scheduler-service/src/test/java/com/iris/platform/scheduler/TestPlatformEventSchedulerService.java
+++ b/platform/arcus-containers/scheduler-service/src/test/java/com/iris/platform/scheduler/TestPlatformEventSchedulerService.java
@@ -125,10 +125,6 @@ public class TestPlatformEventSchedulerService extends IrisMockTestCase {
       replay();
 
       service.onPartitionsChanged(createPartitionChangedEvent(new DefaultPartition(0)));
-
-      // Wait for the async executor to finish scheduling partitions
-      service.stop();
-
       service.fireEventAt(placeId, schedulerAddress, scheduledTime);
       
       // the mock scheduler runs the event immediately
@@ -166,9 +162,6 @@ public class TestPlatformEventSchedulerService extends IrisMockTestCase {
       replay();
 
       service.onPartitionsChanged(createPartitionChangedEvent(new DefaultPartition(0)));
-
-      // Wait for the async executor to finish scheduling partitions
-      service.stop();
 
       verify();
    }


### PR DESCRIPTION
The previous fix using service.stop() shut down the executor entirely, which masked the race condition rather than fixing it. Instead, run the first iteration of PartitionSchedulerJob.schedule() synchronously within onPartitionsChanged, then schedule subsequent runs with the executor using the bucket duration as the initial delay.