### PR TITLE
Fix flaky TestAES.testAesGcmManipulated

### DIFF
--- a/platform/arcus-security/src/test/java/com/iris/security/crypto/TestAES.java
+++ b/platform/arcus-security/src/test/java/com/iris/security/crypto/TestAES.java
@@ -58,7 +58,9 @@ public class TestAES {
         thrown.expect(RuntimeException.class);
         String ctext = aes.encryptSafe("foo", "foo1");
         byte[] tamper = Utils.b64Decode(ctext);
-        tamper[3] = 'A';
+        // Flip a bit so the byte is always altered; assigning a constant is a
+        // no-op ~1/256 of the time when the random GCM IV already holds it.
+        tamper[3] ^= 0x01;
         String tampered = Utils.b64Encode(tamper);
         String decoded = aes.decryptSafe("foo", tampered);
     }


### PR DESCRIPTION
The test tampered a GCM-encrypted blob with `tamper[3] = 'A'` to prove decryption rejects altered ciphertext. Byte 3 falls inside the 12-byte random GCM IV, so when that random byte already equaled 0x41 ('A') the assignment was a no-op, decryption succeeded, and the expected RuntimeException was never thrown -- a ~1/256 failure on every run, independent of JDK. This is what failed the JDK 8 shard on the bump-version-2026.7.1 CI run.

Flip a bit instead of assigning a constant so the byte is always altered, guaranteeing a GCM tag mismatch (AEADBadTagException).