### PR TITLE
Bump dependencies to patch known CVEs

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,11 +46,11 @@ ext.libraries << [
 
 
 // Apache
-		commons_beanutils: "commons-beanutils:commons-beanutils:1.9.4",
+		commons_beanutils: "commons-beanutils:commons-beanutils:1.11.0",
 		commons_cli: "commons-cli:commons-cli:1.6.0",
 		commonsCodec: "commons-codec:commons-codec:1.16.1",
 		commonsConfig: "commons-configuration:commons-configuration:1.8",
-		commonsIO: "commons-io:commons-io:2.11.0",
+		commonsIO: "commons-io:commons-io:2.14.0",
 		commons_math: "org.apache.commons:commons-math3:3.6.1",
 		apacheCommonsValidator: "commons-validator:commons-validator:1.9.0",
 		
@@ -64,7 +64,7 @@ ext.libraries << [
 			exclude group: "org.slf4j", module: "slf4j-log4j12"
 			exclude group: "log4j", module: "log4j"
 		},
-		asyncHTTPClient: "org.asynchttpclient:async-http-client:2.12.4",
+		asyncHTTPClient: "org.asynchttpclient:async-http-client:2.15.0",
 
 // Apache Lucene
 		luceneCore: "org.apache.lucene:lucene-core:8.11.4",
@@ -91,8 +91,8 @@ ext.libraries << [
 		jaxb_api: "javax.xml.bind:jaxb-api:2.3.1",
 
 // Encryption via Bouncy Castle
-		bouncycastle: "org.bouncycastle:bcprov-jdk18on:1.78",
-		bouncycastle_pki: "org.bouncycastle:bcpkix-jdk18on:1.78",
+		bouncycastle: "org.bouncycastle:bcprov-jdk18on:1.79",
+		bouncycastle_pki: "org.bouncycastle:bcpkix-jdk18on:1.79",
 
 // SQL Database
 		sqlite4java: "com.almworks.sqlite4java:sqlite4java:1.0.392",
@@ -103,8 +103,8 @@ ext.libraries << [
 		// guice-multibindings merged into core guice jar in 5.x
 
 // jackson dependencies
-		jacksonCore: "com.fasterxml.jackson.core:jackson-core:2.18.6",
-		jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:2.18.6",
+		jacksonCore: "com.fasterxml.jackson.core:jackson-core:2.18.8",
+		jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:2.18.8",
 
 // kafka dependencies
 		eyekatkafka: dependencies.create("org.apache.kafka:kafka_2.11:0.10.0.0") {
@@ -117,7 +117,7 @@ ext.libraries << [
 			exclude group: "log4j", module: "log4j"
 			exclude group: "org.slf4j", module: "slf4j-log4j12"
 		},
-		zookeeper: dependencies.create("org.apache.zookeeper:zookeeper:3.8.4") {
+		zookeeper: dependencies.create("org.apache.zookeeper:zookeeper:3.8.6") {
 			exclude group: "org.slf4j", module: "slf4j-log4j12"
 			exclude group: "log4j", module: "log4j"
 			exclude group: "junit", module: "junit"
@@ -140,7 +140,7 @@ ext.libraries << [
 		guava: "com.google.guava:guava:33.4.0-jre",
 		google_guava_testlib: "com.google.guava:guava-testlib:33.4.0-jre",
 		gson: "com.google.code.gson:gson:2.11.0",
-		commons_lang: "org.apache.commons:commons-lang3:3.17.0",
+		commons_lang: "org.apache.commons:commons-lang3:3.18.0",
 		eclipse_annotation: "org.eclipse.jdt:org.eclipse.jdt.annotation:1.1.0",
 		handlebars: "com.github.jknack:handlebars:2.2.2",
 		jna: 'net.java.dev.jna:jna:4.4.0',
@@ -193,7 +193,7 @@ ext.libraries << [
 		slf4jJul: "org.slf4j:jul-to-slf4j:2.0.17",
 		slf4jJcl: "org.slf4j:jcl-over-slf4j:2.0.17",
 		slf4jApi: "org.slf4j:slf4j-api:2.0.17",
-		logback: "ch.qos.logback:logback-classic:1.3.14",
+		logback: "ch.qos.logback:logback-classic:1.3.16",
 
 
 // Notifications
@@ -229,7 +229,7 @@ libraries.cucumber = [ libraries.cucumber_junit, libraries.cucumber_groovy, libr
 if (project.hasProperty("netty_override_version"))
 	ext.netty_version = "${netty_override_version}"
 else
-	ext.netty_version = "4.1.128.Final"
+	ext.netty_version = "4.1.135.Final"
 if (project.hasProperty("tcnative_override_version"))
 	ext.tcnative_version = "${tcnative_override_version}"
 else


### PR DESCRIPTION
Drop-in patch/minor upgrades for platform/cloud services (verified against NVD/GitHub Advisories, July 2026):

- io.netty 4.1.128 → 4.1.135.Final (req smuggling, HTTP/2 flood, DNS poisoning)
- jackson-core/databind 2.18.6 → 2.18.8 (CVE-2026-54512/54513 PTV bypass)
- logback-classic 1.3.14 → 1.3.16 (CVE-2024-12798/12801, config ACE/SSRF)
- commons-beanutils 1.9.4 → 1.11.0 (CVE-2025-48734)
- commons-io 2.11.0 → 2.14.0 (CVE-2024-47554 DoS)
- commons-lang3 3.17.0 → 3.18.0 (CVE-2025-48924 DoS)
- bcprov/bcpkix-jdk18on 1.78 → 1.79 (CVE-2025-8916 DoS)
- zookeeper 3.8.4 → 3.8.6 (CVE-2026-24308/24281)
- async-http-client 2.12.4 → 2.15.0 (credential leak on redirect)

Hub agent netty stays pinned at 4.1.60.Final (custom arm_32 native build) and is unaffected by these changes.